### PR TITLE
refactor(mvp): harden runtime and streaming flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,16 +2,12 @@
 OPENAI_API_KEY=sk-your-openai-api-key-here
 GOOGLE_API_KEY=your-google-api-key-here
 
-# Redis Configuration
-REDIS_URL=redis://localhost:6379/0
-REDIS_PASSWORD=
-REDIS_SSL=false
-
 # Application Configuration
-AGENTIC_ADAPTER=vanilla_openai
 ENVIRONMENT=development
 DEBUG=true
-LOG_LEVEL=INFO
+STATE_BACKEND=auto
+REDIS_URL=redis://localhost:6379/0
+CORS_ORIGINS=["http://localhost:8501", "http://127.0.0.1:8501"]
 
 # Server Configuration
 API_HOST=0.0.0.0
@@ -19,21 +15,10 @@ API_PORT=8000
 FRONTEND_HOST=0.0.0.0
 FRONTEND_PORT=8501
 
-# Security
-SECRET_KEY=your-secret-key-here
-CORS_ORIGINS=["http://localhost:8501", "http://127.0.0.1:8501"]
-
-# Performance Tuning
-MAX_CONCURRENT_REQUESTS=10
-REQUEST_TIMEOUT=300
-REDIS_TTL_SECONDS=604800  # 7 days
-
 # LLM Configuration
-DEFAULT_TEMPERATURE=0.7
-MAX_TOKENS=4000
-MODEL_OPENAI=gpt-4-turbo-preview
-MODEL_GOOGLE=gemini-1.5-pro
-
-# Observability
-ENABLE_TELEMETRY=false
-OTLP_ENDPOINT=http://localhost:4317
+OPENAI_MODEL=gpt-4.1-mini
+GOOGLE_MODEL=gemini-2.5-flash
+DEFAULT_TEMPERATURE=0.2
+MAX_OUTPUT_TOKENS=4096
+REQUEST_TIMEOUT_SECONDS=60
+REDIS_TTL_SECONDS=604800

--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,8 @@ redis-data/
 tmp/
 temp/
 
+# Codex project memory
+.codex/
+
 # Security Reports
 bandit-report.json

--- a/README.md
+++ b/README.md
@@ -1,51 +1,76 @@
-# 🛠️ Agentic‑PRD‑Generation
+# Agentic PRD Generation
 
-> **Status — Alpha / Implementation Phase**
-> The project scaffolding is complete, and the core backend logic for the vanilla agent workflow is currently under development.
+Alpha-stage MVP for generating Product Requirements Documents with a small, honest surface area.
 
-## 📖 What is this project?
+## Current Scope
 
-An AI‑powered platform that **iteratively generates Project Requirement Documents (PRDs) _and_ the follow‑up Technical Specification (Tech Spec)** through an agentic workflow.
-The goal is to compare vanilla LLM clients (OpenAI & Google GenAI) with popular agent frameworks (CrewAI, AutoGen, etc.) while visualising every step—outline, draft, critique, revision—in real time.
+- Generate PRDs from a single project idea.
+- Stream state updates from FastAPI to Streamlit over SSE.
+- Use either the OpenAI adapter or the Google GenAI adapter.
+- Persist run state in Redis when available, with automatic fallback to in-memory storage for local development and tests.
 
-## ✨ Core Features (MVP)
+## Not Shipped Yet
 
-| Phase | Feature | Status |
-|-------|---------|----------|
-| **A** | Vanilla workflow using official `openai` and `google-generativeai` Python clients | 🚧 In Progress |
-| **B** | Pluggable adapter modules for frameworks (CrewAI, AutoGen, …) | ⏳ Planned |
-| — | FastAPI backend that streams live updates via SSE | ✅ Implemented |
-| — | Minimal front‑end (Streamlit) showing progress | 🚧 In Progress |
-| — | One‑click **“Generate Tech Spec”** from the approved PRD | ⏳ Planned |
+- Framework comparison adapters such as CrewAI or AutoGen
+- Supervised checkpoints or stop controls
+- Technical specification generation
 
-*See [`docs/PRD.md`](docs/PRD.md) for the full requirements.*
+## Architecture
 
-## 🗺️ Roadmap
+- `backend/`: FastAPI API, runtime setup, adapters, pipeline, and state backends
+- `frontend/`: Streamlit UI for starting runs and following live updates
+- `tests/`: unit and integration coverage for runtime selection, pipeline behavior, streaming, and CLI wiring
 
-1.  **Docs** – ✅ Finalise PRD and Tech Spec.
-2.  **Scaffolding** – ✅ Set up repo structure, CI, and basic FastAPI + Streamlit apps.
-3.  **Phase A** – 🚧 Implement the vanilla LLM workflow, including real LLM calls and connecting the frontend to the backend stream.
-4.  **Phase B** – ⏳ Implement the first framework adapter (e.g., CrewAI).
-5.  **Tech Spec Generator** – ⏳ Build the agent that converts the final PRD into a design doc.
-6.  **Evaluation** – ⏳ Add more framework adapters & generate a comparison report.
+The backend uses lifespan-managed shared resources: `AppSettings`, one `StateStore`, and one `StreamerService` per process.
 
-*Timeline details live inside the PRD.*
+## Quickstart
 
-## 🏗️ Repository Structure
+1. Install dependencies:
 
-```
-backend/     # FastAPI app with routes, services, and agent pipeline
-frontend/    # Streamlit UI application
-agents/      # Shared agent protocols (interfaces)
-docs/        # PRD.md, TECH_SPEC.md, and diagrams
-.github/     # CI workflows and issue templates
+```bash
+pip install -e ".[dev,test]"
 ```
 
-## 🤝 Contributing
+2. Create local configuration:
 
-We welcome issues and discussions.
-A `CONTRIBUTING.md` guide will be added once the core features are stable.
+```bash
+cp .env.example .env
+```
 
-## 📜 License
+3. Add at least one provider key to `.env`.
 
-MIT
+4. Run the backend:
+
+```bash
+agentic-prd --host 0.0.0.0 --port 8000 --reload
+```
+
+5. Run the frontend:
+
+```bash
+streamlit run frontend/app.py --server.port 8501
+```
+
+6. Open `http://localhost:8501`.
+
+## Quality Gates
+
+```bash
+ruff check .
+ruff format --check .
+mypy backend frontend
+pytest
+```
+
+## Docker
+
+Runtime images install only the application package and its runtime dependencies.
+
+```bash
+docker-compose up --build
+```
+
+## Docs
+
+- [`docs/PRD.md`](docs/PRD.md): current MVP product requirements
+- [`docs/TECH_SPEC.md`](docs/TECH_SPEC.md): current architecture and API contract

--- a/backend/agents/base_adapter.py
+++ b/backend/agents/base_adapter.py
@@ -1,17 +1,22 @@
-"""Defines the protocol for agent adapters.
-
-This ensures that any agent implementation, whether a vanilla client or a
-framework-based one (like CrewAI), can be used interchangeably by the
-pipeline runner.
-"""
+"""Defines the protocol and shared exceptions for agent adapters."""
 
 from typing import Protocol
+
+
+class AdapterError(RuntimeError):
+    """Raised when an upstream LLM request fails."""
+
+    def __init__(self, provider: str, message: str):
+        super().__init__(message)
+        self.provider = provider
 
 
 class BaseAdapter(Protocol):
     """
     Protocol for an agent adapter that can be called by the pipeline.
     """
+
+    adapter_type: str
 
     async def call_llm(self, prompt: str) -> str:
         """

--- a/backend/agents/vanilla.py
+++ b/backend/agents/vanilla.py
@@ -1,16 +1,15 @@
-"""
-Vanilla adapter implementation using official OpenAI and Google clients.
-"""
+"""Vanilla adapter implementation using official OpenAI and Google clients."""
 
 import asyncio
-import os
-import traceback
+from importlib import import_module
+from time import perf_counter
 from typing import Literal
 
-import google.generativeai as genai
-from openai import AsyncOpenAI
+import structlog
 
-from backend.agents.base_adapter import BaseAdapter
+from backend.agents.base_adapter import AdapterError, BaseAdapter
+
+logger = structlog.get_logger(__name__)
 
 
 class VanillaAdapter(BaseAdapter):
@@ -18,28 +17,33 @@ class VanillaAdapter(BaseAdapter):
     Implements the BaseAdapter protocol using direct calls to LLM APIs.
     """
 
-    client: AsyncOpenAI | genai.GenerativeModel
-
     def __init__(
         self,
         adapter_type: Literal["vanilla_openai", "vanilla_google"] = "vanilla_openai",
-        model_name: str | None = None,
-    ):
+        *,
+        openai_api_key: str | None = None,
+        google_api_key: str | None = None,
+        openai_model: str = "gpt-4.1-mini",
+        google_model: str = "gemini-2.5-flash",
+        temperature: float = 0.2,
+        max_output_tokens: int = 4096,
+        request_timeout_seconds: float = 60.0,
+    ) -> None:
         self.adapter_type = adapter_type
+        self.temperature = temperature
+        self.max_output_tokens = max_output_tokens
+        self.request_timeout_seconds = request_timeout_seconds
+        self._openai_api_key = openai_api_key
+        self._google_api_key = google_api_key
 
         if self.adapter_type == "vanilla_openai":
-            self.model_name = model_name or "gpt-4.1-mini"
-            api_key = os.getenv("OPENAI_API_KEY")
-            if not api_key:
+            self.model_name = openai_model
+            if not self._openai_api_key:
                 raise ValueError("OPENAI_API_KEY environment variable not set.")
-            self.client = AsyncOpenAI(api_key=api_key)
         elif self.adapter_type == "vanilla_google":
-            self.model_name = model_name or "gemini-2.5-flash"
-            api_key = os.getenv("GOOGLE_API_KEY")
-            if not api_key:
+            self.model_name = google_model
+            if not self._google_api_key:
                 raise ValueError("GOOGLE_API_KEY environment variable not set.")
-            genai.configure(api_key=api_key)
-            self.client = genai.GenerativeModel(self.model_name)
         else:
             raise ValueError(f"Unsupported adapter type: {self.adapter_type}")
 
@@ -47,45 +51,88 @@ class VanillaAdapter(BaseAdapter):
         """
         Calls the underlying language model with a given prompt.
         """
+        started_at = perf_counter()
         try:
             if self.adapter_type == "vanilla_openai":
-                if not isinstance(self.client, AsyncOpenAI):
-                    raise TypeError("Client is not an AsyncOpenAI instance.")
-
-                openai_response = await self.client.chat.completions.create(
-                    model=self.model_name,
-                    messages=[{"role": "user", "content": prompt}],
-                    temperature=0.7,
-                    max_tokens=2048,
-                )
-                openai_content: str = openai_response.choices[0].message.content or ""
-                return openai_content
-
-            elif self.adapter_type == "vanilla_google":
-                if not isinstance(self.client, genai.GenerativeModel):
-                    raise TypeError("Client is not a GenerativeModel instance.")
-
-                print(
-                    ">>> [Google Adapter] About to call generate_content in thread..."
-                )
-                # Run the synchronous SDK call in a separate thread
-                google_response = await asyncio.to_thread(
-                    self.client.generate_content, prompt
-                )
-                print(">>> [Google Adapter] Call to generate_content completed.")
-                google_content: str = google_response.text
-                return google_content
-
+                response = await self._call_openai(prompt)
             else:
-                # This should be unreachable due to the __init__ check
-                raise ValueError(f"Unsupported adapter type: {self.adapter_type}")
+                response = await self._call_google(prompt)
 
-        except Exception:
-            # Aether's Rationale:
-            # Catching a broad exception here to handle various API errors
-            # (e.g., network issues, authentication failures, rate limits).
-            # In a production system, this would be replaced with more granular
-            # error handling and logging.
-            error_details: str = str(traceback.format_exc())
-            print(f"Error calling LLM: {error_details}")
-            return f"Error: Could not get a response from the model. Details: {error_details}"
+            logger.info(
+                "llm_call_succeeded",
+                adapter=self.adapter_type,
+                model=self.model_name,
+                duration_seconds=round(perf_counter() - started_at, 3),
+            )
+            return response
+        except AdapterError:
+            logger.warning(
+                "llm_call_failed",
+                adapter=self.adapter_type,
+                model=self.model_name,
+                duration_seconds=round(perf_counter() - started_at, 3),
+                exc_info=True,
+            )
+            raise
+
+    async def _call_openai(self, prompt: str) -> str:
+        """Call the OpenAI Chat Completions API."""
+        try:
+            openai_module = import_module("openai")
+            async_openai_cls = openai_module.AsyncOpenAI
+        except ModuleNotFoundError as exc:
+            raise AdapterError("openai", "The OpenAI SDK is not installed.") from exc
+
+        client = async_openai_cls(
+            api_key=self._openai_api_key,
+            timeout=self.request_timeout_seconds,
+        )
+        try:
+            openai_response = await client.chat.completions.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=self.temperature,
+                max_tokens=self.max_output_tokens,
+            )
+            openai_content: str = openai_response.choices[0].message.content or ""
+        except Exception as exc:
+            raise AdapterError("openai", f"OpenAI request failed: {exc}") from exc
+        finally:
+            await client.close()
+
+        if not openai_content.strip():
+            raise AdapterError("openai", "OpenAI returned an empty response.")
+        return openai_content
+
+    async def _call_google(self, prompt: str) -> str:
+        """Call the Google GenAI API using the supported SDK."""
+        try:
+            genai_module = import_module("google.genai")
+            types_module = import_module("google.genai.types")
+        except ModuleNotFoundError as exc:
+            raise AdapterError(
+                "google", "The Google GenAI SDK is not installed."
+            ) from exc
+
+        client = genai_module.Client(api_key=self._google_api_key)
+        try:
+            response = await asyncio.to_thread(
+                client.models.generate_content,
+                model=self.model_name,
+                contents=prompt,
+                config=types_module.GenerateContentConfig(
+                    temperature=self.temperature,
+                    max_output_tokens=self.max_output_tokens,
+                ),
+            )
+        except Exception as exc:
+            raise AdapterError("google", f"Google request failed: {exc}") from exc
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                await asyncio.to_thread(close)
+
+        google_content = getattr(response, "text", "") or ""
+        if not google_content.strip():
+            raise AdapterError("google", "Google returned an empty response.")
+        return google_content

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,0 +1,60 @@
+"""FastAPI dependency providers backed by shared app runtime state."""
+
+from typing import Annotated, cast
+
+from fastapi import Depends, HTTPException, Request, status
+
+from backend.agents.base_adapter import BaseAdapter
+from backend.agents.vanilla import VanillaAdapter
+from backend.models import GeneratePRDRequest
+from backend.runtime import AppRuntime
+from backend.services.streamer import StreamerService
+from backend.settings import AppSettings
+from backend.state.base import StateStore
+
+
+def get_runtime(request: Request) -> AppRuntime:
+    """Return the process-level runtime container."""
+    return cast("AppRuntime", request.app.state.runtime)
+
+
+def get_settings(runtime: Annotated[AppRuntime, Depends(get_runtime)]) -> AppSettings:
+    """Return application settings."""
+    return runtime.settings
+
+
+def get_state_store(
+    runtime: Annotated[AppRuntime, Depends(get_runtime)],
+) -> StateStore:
+    """Return the shared state store."""
+    return runtime.state_store
+
+
+def get_streamer_service(
+    runtime: Annotated[AppRuntime, Depends(get_runtime)],
+) -> StreamerService:
+    """Return the shared streamer service."""
+    return runtime.streamer
+
+
+def get_agent_adapter(
+    request: GeneratePRDRequest,
+    settings: Annotated[AppSettings, Depends(get_settings)],
+) -> BaseAdapter:
+    """Instantiate the selected LLM adapter."""
+    try:
+        return VanillaAdapter(
+            adapter_type=request.adapter,
+            openai_api_key=settings.openai_api_key,
+            google_api_key=settings.google_api_key,
+            openai_model=settings.openai_model,
+            google_model=settings.google_model,
+            temperature=settings.default_temperature,
+            max_output_tokens=settings.max_output_tokens,
+            request_timeout_seconds=settings.request_timeout_seconds,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc

--- a/backend/logging.py
+++ b/backend/logging.py
@@ -1,0 +1,27 @@
+"""Logging configuration helpers."""
+
+import logging
+
+import structlog
+
+
+def configure_logging(debug: bool) -> None:
+    """Configure standard and structured logging once per process."""
+    logging.basicConfig(
+        format="%(message)s",
+        level=logging.DEBUG if debug else logging.INFO,
+    )
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.dev.ConsoleRenderer(),
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -45,19 +45,19 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
     return app
 
 
-app = create_app()
+DEFAULT_SETTINGS = AppSettings()
+app = create_app(DEFAULT_SETTINGS)
 
 
 def cli(argv: list[str] | None = None) -> int:
     """Run the API server from the installed console script."""
-    settings = AppSettings()
     parser = argparse.ArgumentParser(description="Run the Agentic PRD API server.")
-    parser.add_argument("--host", default=settings.api_host)
-    parser.add_argument("--port", type=int, default=settings.api_port)
+    parser.add_argument("--host", default=DEFAULT_SETTINGS.api_host)
+    parser.add_argument("--port", type=int, default=DEFAULT_SETTINGS.api_port)
     parser.add_argument(
         "--reload",
         action=argparse.BooleanOptionalAction,
-        default=settings.environment == "development",
+        default=DEFAULT_SETTINGS.environment == "development",
     )
     args = parser.parse_args(argv)
     uvicorn.run(

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,49 +1,73 @@
-"""
-Main FastAPI application entry point.
+"""Main FastAPI application entry point."""
 
-This module sets up the FastAPI application with all routes, middleware,
-and configuration for the Agentic PRD Generation platform.
-"""
+import argparse
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
-from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import uvicorn
 
 from backend.routes.generation import router as generation_router
 from backend.routes.health import router as health_router
+from backend.runtime import build_runtime, close_runtime
+from backend.settings import AppSettings
 
-# Load environment variables from .env file
-load_dotenv()
 
-# Create FastAPI app
-app = FastAPI(
-    title="Agentic PRD Generation API",
-    description="AI-powered platform for iterative PRD and Technical Specification generation",
-    version="0.1.0",
-    docs_url="/docs",
-    redoc_url="/redoc",
-)
+def create_app(settings: AppSettings | None = None) -> FastAPI:
+    """Create a configured FastAPI application."""
+    app_settings = settings or AppSettings()
 
-# Add CORS middleware
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:8501", "http://127.0.0.1:8501"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        runtime = await build_runtime(app_settings)
+        app.state.runtime = runtime
+        yield
+        await close_runtime(runtime)
 
-# Include routers
-app.include_router(health_router, prefix="", tags=["health"])
-app.include_router(generation_router, prefix="/api/v1", tags=["generation"])
+    app = FastAPI(
+        title=app_settings.app_name,
+        description="AI-powered platform for iterative PRD generation.",
+        version=app_settings.app_version,
+        docs_url="/docs",
+        redoc_url="/redoc",
+        lifespan=lifespan,
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=app_settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(health_router, prefix="", tags=["health"])
+    app.include_router(generation_router, prefix="/api/v1", tags=["generation"])
+    return app
+
+
+app = create_app()
+
+
+def cli(argv: list[str] | None = None) -> int:
+    """Run the API server from the installed console script."""
+    settings = AppSettings()
+    parser = argparse.ArgumentParser(description="Run the Agentic PRD API server.")
+    parser.add_argument("--host", default=settings.api_host)
+    parser.add_argument("--port", type=int, default=settings.api_port)
+    parser.add_argument(
+        "--reload",
+        action=argparse.BooleanOptionalAction,
+        default=settings.environment == "development",
+    )
+    args = parser.parse_args(argv)
+    uvicorn.run(
+        "backend.main:app",
+        host=args.host,  # nosec B104
+        port=args.port,
+        reload=args.reload,
+    )
+    return 0
 
 
 if __name__ == "__main__":
-    import uvicorn
-
-    uvicorn.run(
-        "backend.main:app",
-        host="0.0.0.0",  # nosec B104
-        port=8000,
-        reload=True,
-    )
+    raise SystemExit(cli())

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,13 +1,12 @@
-"""Pydantic models for the Agentic PRD Generation platform.
-
-These models define the shape of data used throughout the application,
-ensuring type safety and clear contracts between components.
-"""
+"""Pydantic models for the Agentic PRD Generation platform."""
 
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+WorkflowStep = Literal["Outline", "Draft", "Critique", "Revise", "Complete", "Error"]
+AdapterType = Literal["vanilla_openai", "vanilla_google"]
 
 
 class PRDState(BaseModel, frozen=True):
@@ -18,18 +17,36 @@ class PRDState(BaseModel, frozen=True):
     """
 
     run_id: str = Field(..., description="Unique identifier for the generation run.")
-    step: Literal[
-        "Outline", "Research", "Draft", "Critique", "Revise", "Complete", "Error"
-    ] = Field(..., description="The current step in the agentic workflow.")
+    idea: str = Field(..., description="The original product idea for the run.")
+    step: WorkflowStep = Field(..., description="The current step in the workflow.")
     content: str = Field(..., description="The full Markdown content of the PRD.")
     revision: int = Field(..., description="The revision number, starting from 0.")
     diff: str | None = Field(
         None, description="The unified diff from the previous revision."
     )
+    error: str | None = Field(
+        None,
+        description="Terminal error details when the run ends in an error state.",
+    )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         description="Timestamp when this state was created (UTC).",
     )
+
+    def to_event_payload(self) -> dict[str, Any]:
+        """Return the public SSE payload for this run state."""
+        return self.model_dump(
+            mode="json",
+            include={
+                "run_id",
+                "step",
+                "content",
+                "revision",
+                "diff",
+                "error",
+                "created_at",
+            },
+        )
 
 
 class GeneratePRDRequest(BaseModel):
@@ -38,11 +55,9 @@ class GeneratePRDRequest(BaseModel):
     """
 
     idea: str = Field(..., description="The high-level project idea.", min_length=1)
-    autonomy_level: Literal["Full", "Supervised"] = Field(
-        "Full", description="The level of autonomy for the agentic workflow."
-    )
-    adapter: Literal["vanilla_openai", "vanilla_google", "crewai"] = Field(
-        "vanilla_openai", description="The agent adapter to use for the run."
+    adapter: AdapterType = Field(
+        "vanilla_openai",
+        description="The implemented agent adapter to use for the run.",
     )
 
 

--- a/backend/pipelines/pipeline_runner.py
+++ b/backend/pipelines/pipeline_runner.py
@@ -1,12 +1,11 @@
 """Functional async pipeline for running the agentic workflow."""
 
-import asyncio
 from collections.abc import Awaitable, Callable
-import traceback
 
 from diff_match_patch import diff_match_patch
+import structlog
 
-from backend.agents.base_adapter import BaseAdapter
+from backend.agents.base_adapter import AdapterError, BaseAdapter
 from backend.models import PRDState
 from backend.pipelines.prompts import (
     CRITIQUE_PROMPT,
@@ -16,6 +15,8 @@ from backend.pipelines.prompts import (
 )
 from backend.services.streamer import StreamerService
 from backend.state.base import StateStore
+
+logger = structlog.get_logger(__name__)
 
 MAX_REVISIONS = 3
 APPROVAL_PHRASE = "No issues found."
@@ -30,43 +31,32 @@ def create_diff(text1: str, text2: str) -> str:
 
 
 async def outline_step(
-    current_state: PRDState, state_store: StateStore, adapter: BaseAdapter
+    current_state: PRDState,
+    state_store: StateStore,
+    adapter: BaseAdapter,
+    streamer: StreamerService | None,
 ) -> PRDState:
     """Generate the outline for the PRD."""
-    print("Running outline step...")
-    idea = current_state.content.replace("# PRD for ", "").replace(
-        "\n\n*Initial state.*", ""
-    )
-    prompt = OUTLINE_PROMPT.format(idea=idea)
+    logger.info("pipeline_step_started", run_id=current_state.run_id, step="Outline")
+    prompt = OUTLINE_PROMPT.format(idea=current_state.idea)
     new_content: str = await adapter.call_llm(prompt)
-
-    new_state = PRDState(
-        run_id=current_state.run_id,
-        step="Draft",
-        content=new_content,
-        revision=current_state.revision + 1,
-        diff=create_diff(current_state.content, new_content),
-    )
-    await state_store.save(new_state)
+    new_state = _next_state(current_state, step="Outline", content=new_content)
+    await _persist_state(new_state, state_store, streamer)
     return new_state
 
 
 async def draft_step(
-    current_state: PRDState, state_store: StateStore, adapter: BaseAdapter
+    current_state: PRDState,
+    state_store: StateStore,
+    adapter: BaseAdapter,
+    streamer: StreamerService | None,
 ) -> PRDState:
     """Generate the draft for the PRD."""
-    print("Running draft step...")
+    logger.info("pipeline_step_started", run_id=current_state.run_id, step="Draft")
     prompt = DRAFT_PROMPT.format(outline=current_state.content)
     new_content: str = await adapter.call_llm(prompt)
-
-    new_state = PRDState(
-        run_id=current_state.run_id,
-        step="Critique",
-        content=new_content,
-        revision=current_state.revision + 1,
-        diff=create_diff(current_state.content, new_content),
-    )
-    await state_store.save(new_state)
+    new_state = _next_state(current_state, step="Draft", content=new_content)
+    await _persist_state(new_state, state_store, streamer)
     return new_state
 
 
@@ -78,53 +68,51 @@ async def critique_and_revise_loop(
 ) -> PRDState:
     """Run the critique and revise loop until the PRD is approved."""
     for i in range(MAX_REVISIONS):
-        print(f"Running critique step (Revision {i + 1}/{MAX_REVISIONS})...")
-        critique_prompt = CRITIQUE_PROMPT.format(draft=current_state.content)
-        critique: str = await adapter.call_llm(critique_prompt)
-
-        if APPROVAL_PHRASE in critique:
-            print("PRD approved. Exiting revision loop.")
-            break
-
-        content_with_critique = (
-            f"{current_state.content}\n\n---\n\n## Critique\n\n{critique}"
-        )
-        critique_state = PRDState(
+        logger.info(
+            "pipeline_step_started",
             run_id=current_state.run_id,
             step="Critique",
-            content=content_with_critique,
-            revision=current_state.revision + 1,
-            diff=create_diff(current_state.content, content_with_critique),
+            revision_attempt=i + 1,
         )
-        await state_store.save(critique_state)
-        if streamer:
-            await streamer.push_data(critique_state.run_id, critique_state.model_dump())
+        critique_prompt = CRITIQUE_PROMPT.format(draft=current_state.content)
+        critique: str = await adapter.call_llm(critique_prompt)
+        critique_state = _next_state(
+            current_state,
+            step="Critique",
+            content=current_state.content,
+            diff=None,
+        )
+        await _persist_state(critique_state, state_store, streamer)
+        current_state = critique_state
 
-        print(f"Running revise step (Revision {i + 1}/{MAX_REVISIONS})...")
+        if APPROVAL_PHRASE in critique:
+            logger.info("pipeline_prd_approved", run_id=current_state.run_id)
+            break
+
+        logger.info(
+            "pipeline_step_started",
+            run_id=current_state.run_id,
+            step="Revise",
+            revision_attempt=i + 1,
+        )
         revise_prompt = REVISE_PROMPT.format(
             draft=current_state.content, critique=critique
         )
         new_content: str = await adapter.call_llm(revise_prompt)
-
-        revised_state = PRDState(
-            run_id=current_state.run_id,
-            step="Critique",  # Stay in critique for the next loop iteration
+        revised_state = _next_state(
+            current_state,
+            step="Revise",
             content=new_content,
-            revision=critique_state.revision + 1,
-            diff=create_diff(critique_state.content, new_content),
         )
-        await state_store.save(revised_state)
-        if streamer:
-            await streamer.push_data(revised_state.run_id, revised_state.model_dump())
+        await _persist_state(revised_state, state_store, streamer)
         current_state = revised_state
-        await asyncio.sleep(1)  # Small delay between revisions
 
     return current_state
 
 
 PIPELINE_STAGES: list[
     Callable[
-        [PRDState, StateStore, BaseAdapter],
+        [PRDState, StateStore, BaseAdapter, StreamerService | None],
         Awaitable[PRDState],
     ]
 ] = [outline_step, draft_step]
@@ -140,44 +128,72 @@ async def run_pipeline(
     Runs the full agentic pipeline from outline to completion.
     """
     current_state = initial_state
-    if streamer:
-        await streamer.push_data(current_state.run_id, current_state.model_dump())
 
     try:
         for step_func in PIPELINE_STAGES:
-            current_state = await step_func(current_state, state_store, adapter)
-            if streamer:
-                await streamer.push_data(
-                    current_state.run_id, current_state.model_dump()
-                )
+            current_state = await step_func(
+                current_state,
+                state_store,
+                adapter,
+                streamer,
+            )
 
         current_state = await critique_and_revise_loop(
             current_state, state_store, adapter, streamer
         )
 
-        final_state = PRDState(
-            run_id=current_state.run_id,
+        final_state = _next_state(
+            current_state,
             step="Complete",
             content=current_state.content,
-            revision=current_state.revision + 1,
-            diff=create_diff(current_state.content, current_state.content),
+            diff=None,
         )
-        await state_store.save(final_state)
-        if streamer:
-            await streamer.push_data(final_state.run_id, final_state.model_dump())
+        await _persist_state(final_state, state_store, streamer)
+        logger.info("pipeline_completed", run_id=current_state.run_id)
 
-    except Exception:
-        error_details = str(traceback.format_exc())
-        print(f"Error during pipeline: {error_details}")
-        error_state = PRDState(
+    except AdapterError as exc:
+        logger.warning(
+            "pipeline_failed",
             run_id=current_state.run_id,
-            step="Error",
-            content=f"{current_state.content}\n\n---\n\n**Pipeline Error:**\n`{error_details}`",
-            revision=current_state.revision + 1,
-            diff="Error occurred.",
+            provider=exc.provider,
+            exc_info=True,
         )
-        await state_store.save(error_state)
-        if streamer:
-            await streamer.push_data(error_state.run_id, error_state.model_dump())
+        error_state = _next_state(
+            current_state,
+            step="Error",
+            content=current_state.content,
+            diff=None,
+            error=str(exc),
+        )
+        await _persist_state(error_state, state_store, streamer)
 
-    print("Pipeline complete.")
+
+def _next_state(
+    current_state: PRDState,
+    *,
+    step: str,
+    content: str,
+    diff: str | None = None,
+    error: str | None = None,
+) -> PRDState:
+    """Build the next immutable PRD state."""
+    return PRDState(
+        run_id=current_state.run_id,
+        idea=current_state.idea,
+        step=step,
+        content=content,
+        revision=current_state.revision + 1,
+        diff=create_diff(current_state.content, content) if diff is None else diff,
+        error=error,
+    )
+
+
+async def _persist_state(
+    state: PRDState,
+    state_store: StateStore,
+    streamer: StreamerService | None,
+) -> None:
+    """Persist a state update and publish it to subscribers."""
+    await state_store.save(state)
+    if streamer:
+        await streamer.publish(state.run_id, state.to_event_payload())

--- a/backend/pipelines/pipeline_runner.py
+++ b/backend/pipelines/pipeline_runner.py
@@ -159,14 +159,23 @@ async def run_pipeline(
             provider=exc.provider,
             exc_info=True,
         )
-        error_state = _next_state(
-            current_state,
-            step="Error",
-            content=current_state.content,
-            diff=None,
-            error=str(exc),
+        await _persist_terminal_error(
+            current_state=current_state,
+            state_store=state_store,
+            streamer=streamer,
+            error_message=str(exc),
         )
-        await _persist_state(error_state, state_store, streamer)
+    except Exception as exc:
+        logger.exception(
+            "pipeline_failed_unexpectedly",
+            run_id=current_state.run_id,
+        )
+        await _persist_terminal_error(
+            current_state=current_state,
+            state_store=state_store,
+            streamer=streamer,
+            error_message=f"Unexpected pipeline error: {exc}",
+        )
 
 
 def _next_state(
@@ -201,3 +210,27 @@ async def _persist_state(
     await state_store.save(state)
     if streamer:
         await streamer.publish(state.run_id, state.to_event_payload())
+
+
+async def _persist_terminal_error(
+    *,
+    current_state: PRDState,
+    state_store: StateStore,
+    streamer: StreamerService | None,
+    error_message: str,
+) -> None:
+    """Best-effort persistence for terminal pipeline failures."""
+    error_state = _next_state(
+        current_state,
+        step="Error",
+        content=current_state.content,
+        diff=None,
+        error=error_message,
+    )
+    try:
+        await _persist_state(error_state, state_store, streamer)
+    except Exception:
+        logger.exception(
+            "pipeline_error_persistence_failed",
+            run_id=current_state.run_id,
+        )

--- a/backend/pipelines/pipeline_runner.py
+++ b/backend/pipelines/pipeline_runner.py
@@ -20,6 +20,7 @@ logger = structlog.get_logger(__name__)
 
 MAX_REVISIONS = 3
 APPROVAL_PHRASE = "No issues found."
+AUTO_DIFF = object()
 
 
 def create_diff(text1: str, text2: str) -> str:
@@ -173,17 +174,20 @@ def _next_state(
     *,
     step: str,
     content: str,
-    diff: str | None = None,
+    diff: str | None | object = AUTO_DIFF,
     error: str | None = None,
 ) -> PRDState:
     """Build the next immutable PRD state."""
+    next_diff = (
+        create_diff(current_state.content, content) if diff is AUTO_DIFF else diff
+    )
     return PRDState(
         run_id=current_state.run_id,
         idea=current_state.idea,
         step=step,
         content=content,
         revision=current_state.revision + 1,
-        diff=create_diff(current_state.content, content) if diff is None else diff,
+        diff=next_diff,
         error=error,
     )
 

--- a/backend/routes/generation.py
+++ b/backend/routes/generation.py
@@ -20,6 +20,7 @@ from backend.services.streamer import StreamerService
 from backend.state.base import StateStore
 
 router = APIRouter()
+TERMINAL_STEPS = {"Complete", "Error"}
 
 
 @router.post(
@@ -83,7 +84,10 @@ async def stream_prd(
     async def event_publisher() -> AsyncIterator[dict[str, str]]:
         last_revision = latest_state.revision
         try:
-            yield _to_sse_message(latest_state.to_event_payload())
+            latest_payload = latest_state.to_event_payload()
+            yield _to_sse_message(latest_payload)
+            if latest_payload["step"] in TERMINAL_STEPS:
+                return
             while True:
                 payload = await queue.get()
                 revision = int(payload.get("revision", last_revision))
@@ -91,6 +95,8 @@ async def stream_prd(
                     continue
                 last_revision = max(last_revision, revision)
                 yield _to_sse_message(payload)
+                if payload["step"] in TERMINAL_STEPS:
+                    return
         finally:
             await streamer_service.remove_subscriber(run_id, queue)
 

--- a/backend/routes/generation.py
+++ b/backend/routes/generation.py
@@ -91,9 +91,9 @@ async def stream_prd(
             while True:
                 payload = await queue.get()
                 revision = int(payload.get("revision", last_revision))
-                if revision <= last_revision and payload.get("step") != "Error":
+                if revision <= last_revision:
                     continue
-                last_revision = max(last_revision, revision)
+                last_revision = revision
                 yield _to_sse_message(payload)
                 if payload["step"] in TERMINAL_STEPS:
                     return

--- a/backend/routes/generation.py
+++ b/backend/routes/generation.py
@@ -1,67 +1,25 @@
 """API routes for PRD and Tech Spec generation workflows."""
 
-from typing import Annotated, Literal, cast
+from collections.abc import AsyncIterator
+import json
+from typing import Annotated
 import uuid
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sse_starlette.sse import EventSourceResponse
 
 from backend.agents.base_adapter import BaseAdapter
-from backend.agents.vanilla import VanillaAdapter
+from backend.dependencies import (
+    get_agent_adapter,
+    get_state_store,
+    get_streamer_service,
+)
 from backend.models import GeneratePRDRequest, GeneratePRDResponse, PRDState
 from backend.pipelines.pipeline_runner import run_pipeline
 from backend.services.streamer import StreamerService
 from backend.state.base import StateStore
-from backend.state.redis_store import RedisStore
 
 router = APIRouter()
-
-
-# Aether's Rationale:
-# Using FastAPI's dependency injection system is the standard for managing
-# dependencies like database connections or external service clients. It makes
-# the application more modular, easier to test (by overriding dependencies),
-# and aligns with FastAPI best practices.
-
-
-# These functions act as dependency providers.
-def get_state_store() -> StateStore:
-    """Dependency to get the application's state store."""
-    try:
-        return RedisStore()
-    except ConnectionError as e:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Could not connect to Redis: {e}",
-        ) from e
-
-
-def get_streamer_service() -> StreamerService:
-    """Dependency to get the streamer service."""
-    return StreamerService()
-
-
-def get_agent_adapter(request: GeneratePRDRequest) -> BaseAdapter:
-    """Selects and instantiates the correct agent adapter based on the request."""
-    adapter_type = request.adapter
-    if adapter_type in ("vanilla_openai", "vanilla_google"):
-        vanilla_adapter_type = cast(
-            "Literal['vanilla_openai', 'vanilla_google']", adapter_type
-        )
-        try:
-            return VanillaAdapter(adapter_type=vanilla_adapter_type)
-        except ValueError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(e),
-            ) from e
-    if adapter_type == "crewai":
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="The 'crewai' adapter is not yet available.",
-        )
-    # This should be unreachable due to Pydantic validation
-    raise ValueError(f"Unknown adapter type: {adapter_type}")
 
 
 @router.post(
@@ -83,9 +41,11 @@ async def generate_prd(
     run_id = str(uuid.uuid4())
     initial_state = PRDState(
         run_id=run_id,
+        idea=request.idea,
         step="Outline",
-        content=f"# PRD for {request.idea}\n\n*Initial state.*",
+        content=f"# PRD for {request.idea}\n\n_Starting outline generation..._",
         revision=0,
+        error=None,
     )
     await state_store.save(initial_state)
 
@@ -107,12 +67,36 @@ async def generate_prd(
 )
 async def stream_prd(
     run_id: str,
+    state_store: Annotated[StateStore, Depends(get_state_store)],
     streamer_service: Annotated[StreamerService, Depends(get_streamer_service)],
 ) -> EventSourceResponse:
     """Establish an SSE connection for the given run ID."""
-    # Aether's Rationale:
-    # The streamer service needs to be a singleton or managed by a robust
-    # dependency injection system to handle multiple concurrent streams.
-    # For this project's scope, instantiating it per-request is acceptable,
-    # but in a larger-scale app, we would manage its lifecycle carefully.
-    return await streamer_service.create_event_stream(run_id)
+    queue = await streamer_service.add_subscriber(run_id)
+    latest_state = await state_store.get(run_id)
+    if latest_state is None:
+        await streamer_service.remove_subscriber(run_id, queue)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No PRD run found for run_id '{run_id}'.",
+        )
+
+    async def event_publisher() -> AsyncIterator[dict[str, str]]:
+        last_revision = latest_state.revision
+        try:
+            yield _to_sse_message(latest_state.to_event_payload())
+            while True:
+                payload = await queue.get()
+                revision = int(payload.get("revision", last_revision))
+                if revision <= last_revision and payload.get("step") != "Error":
+                    continue
+                last_revision = max(last_revision, revision)
+                yield _to_sse_message(payload)
+        finally:
+            await streamer_service.remove_subscriber(run_id, queue)
+
+    return EventSourceResponse(event_publisher())
+
+
+def _to_sse_message(payload: dict[str, object]) -> dict[str, str]:
+    """Serialize a state payload into an SSE message."""
+    return {"event": "message", "data": json.dumps(payload)}

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -1,21 +1,47 @@
-"""Health check endpoints for monitoring and Docker health checks."""
+"""Health and readiness endpoints."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Request, status
+from fastapi.responses import JSONResponse
+
+from backend.dependencies import get_runtime
+from backend.runtime import AppRuntime
 
 router = APIRouter()
 
 
 @router.get("/health")
-async def health_check() -> dict[str, str]:
+async def health_check(
+    runtime: AppRuntime = Depends(get_runtime),
+) -> dict[str, str]:
     """Basic health check endpoint."""
-    return {"status": "healthy", "service": "agentic-prd-generation"}
+    return {
+        "status": "healthy",
+        "service": "agentic-prd-generation",
+        "version": runtime.settings.app_version,
+    }
+
+
+@router.get("/ready")
+async def readiness_check(
+    runtime: AppRuntime = Depends(get_runtime),
+) -> JSONResponse:
+    """Readiness check for the selected state backend."""
+    ready = await runtime.state_store.ping()
+    status_code = status.HTTP_200_OK if ready else status.HTTP_503_SERVICE_UNAVAILABLE
+    payload = {
+        "status": "ready" if ready else "not_ready",
+        "state_backend": runtime.state_store.backend_name,
+    }
+    return JSONResponse(content=payload, status_code=status_code)
 
 
 @router.get("/")
-async def root() -> dict[str, str]:
+async def root(request: Request) -> dict[str, str]:
     """Root endpoint with API information."""
+    runtime: AppRuntime = request.app.state.runtime
     return {
         "message": "Agentic PRD Generation API",
-        "version": "0.1.0",
+        "version": runtime.settings.app_version,
         "docs": "/docs",
+        "ready": "/ready",
     }

--- a/backend/runtime.py
+++ b/backend/runtime.py
@@ -1,0 +1,69 @@
+"""Application runtime resources and lifecycle helpers."""
+
+from dataclasses import dataclass
+
+import structlog
+
+from backend.logging import configure_logging
+from backend.services.streamer import StreamerService
+from backend.settings import AppSettings
+from backend.state.base import StateStore
+from backend.state.in_memory_store import InMemoryStore
+from backend.state.redis_store import RedisStore
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(slots=True)
+class AppRuntime:
+    """Shared application resources."""
+
+    settings: AppSettings
+    state_store: StateStore
+    streamer: StreamerService
+
+
+async def build_runtime(settings: AppSettings) -> AppRuntime:
+    """Create shared process-level resources."""
+    configure_logging(settings.debug)
+    state_store = await _build_state_store(settings)
+    streamer = StreamerService()
+    logger.info(
+        "app_runtime_initialized",
+        environment=settings.environment,
+        state_backend=state_store.backend_name,
+    )
+    return AppRuntime(settings=settings, state_store=state_store, streamer=streamer)
+
+
+async def close_runtime(runtime: AppRuntime) -> None:
+    """Release shared resources on shutdown."""
+    await runtime.state_store.close()
+    logger.info("app_runtime_closed", state_backend=runtime.state_store.backend_name)
+
+
+async def _build_state_store(settings: AppSettings) -> StateStore:
+    """Select a concrete state store based on configuration and availability."""
+    if settings.state_backend == "memory":
+        return InMemoryStore()
+
+    redis_store = RedisStore(
+        redis_url=settings.redis_url,
+        ttl_seconds=settings.redis_ttl_seconds,
+    )
+    redis_ready = await redis_store.ping()
+    if redis_ready:
+        return redis_store
+
+    if settings.state_backend == "redis":
+        msg = "Redis was selected explicitly but is not reachable."
+        raise RuntimeError(msg)
+
+    logger.warning(
+        "state_store_fallback",
+        requested_backend=settings.state_backend,
+        fallback_backend="memory",
+        redis_url=settings.redis_url,
+    )
+    await redis_store.close()
+    return InMemoryStore()

--- a/backend/runtime.py
+++ b/backend/runtime.py
@@ -56,6 +56,7 @@ async def _build_state_store(settings: AppSettings) -> StateStore:
         return redis_store
 
     if settings.state_backend == "redis":
+        await redis_store.close()
         msg = "Redis was selected explicitly but is not reachable."
         raise RuntimeError(msg)
 

--- a/backend/services/streamer.py
+++ b/backend/services/streamer.py
@@ -1,9 +1,8 @@
 """Service for streaming state updates to the frontend via SSE."""
 
 import asyncio
+from collections import defaultdict
 from typing import Any
-
-from sse_starlette.sse import EventSourceResponse
 
 
 class StreamerService:
@@ -12,29 +11,33 @@ class StreamerService:
     """
 
     def __init__(self) -> None:
-        self.queues: dict[str, asyncio.Queue] = {}
+        self._queues: dict[str, set[asyncio.Queue[dict[str, Any]]]] = defaultdict(set)
+        self._lock = asyncio.Lock()
 
-    async def create_event_stream(self, run_id: str) -> EventSourceResponse:
-        """
-        Creates a new event stream for a given run ID.
-        """
-        if run_id not in self.queues:
-            self.queues[run_id] = asyncio.Queue()
+    async def add_subscriber(self, run_id: str) -> asyncio.Queue[dict[str, Any]]:
+        """Create and register a subscriber queue for a run."""
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        async with self._lock:
+            self._queues[run_id].add(queue)
+        return queue
 
-        async def event_publisher() -> Any:
-            try:
-                while True:
-                    data = await self.queues[run_id].get()
-                    yield data
-            except asyncio.CancelledError:
-                # Clean up the queue when the client disconnects
-                del self.queues[run_id]
+    async def remove_subscriber(
+        self,
+        run_id: str,
+        queue: asyncio.Queue[dict[str, Any]],
+    ) -> None:
+        """Remove a subscriber queue for a run."""
+        async with self._lock:
+            subscribers = self._queues.get(run_id)
+            if not subscribers:
+                return
+            subscribers.discard(queue)
+            if not subscribers:
+                self._queues.pop(run_id, None)
 
-        return EventSourceResponse(event_publisher())
-
-    async def push_data(self, run_id: str, data: Any) -> None:
-        """
-        Pushes data to the appropriate stream.
-        """
-        if run_id in self.queues:
-            await self.queues[run_id].put({"data": data})
+    async def publish(self, run_id: str, data: dict[str, Any]) -> None:
+        """Broadcast a payload to all subscribers for a run."""
+        async with self._lock:
+            subscribers = list(self._queues.get(run_id, set()))
+        for queue in subscribers:
+            await queue.put(data)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,42 @@
+"""Application settings loaded from environment variables."""
+
+from typing import Literal
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AppSettings(BaseSettings):
+    """Central application configuration."""
+
+    app_name: str = "Agentic PRD Generation API"
+    app_version: str = "0.1.0"
+    environment: Literal["development", "test", "production"] = "development"
+    debug: bool = False
+
+    api_host: str = "0.0.0.0"
+    api_port: int = 8000
+    cors_origins: list[str] = Field(
+        default_factory=lambda: [
+            "http://localhost:8501",
+            "http://127.0.0.1:8501",
+        ]
+    )
+
+    state_backend: Literal["auto", "redis", "memory"] = "auto"
+    redis_url: str = "redis://localhost:6379/0"
+    redis_ttl_seconds: int = 60 * 60 * 24 * 7
+
+    openai_api_key: str | None = None
+    google_api_key: str | None = None
+    openai_model: str = "gpt-4.1-mini"
+    google_model: str = "gemini-2.5-flash"
+    default_temperature: float = 0.2
+    max_output_tokens: int = 4096
+    request_timeout_seconds: float = 60.0
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )

--- a/backend/state/base.py
+++ b/backend/state/base.py
@@ -10,6 +10,8 @@ class StateStore(Protocol):
     Protocol for a key-value store that persists PRDState.
     """
 
+    backend_name: str
+
     async def save(self, state: PRDState) -> None:
         """
         Saves the PRD state.
@@ -30,4 +32,12 @@ class StateStore(Protocol):
         Returns:
             The PRD state object if found, otherwise None.
         """
+        ...
+
+    async def ping(self) -> bool:
+        """Return whether the backing store is healthy."""
+        ...
+
+    async def close(self) -> None:
+        """Release any open store resources."""
         ...

--- a/backend/state/in_memory_store.py
+++ b/backend/state/in_memory_store.py
@@ -15,6 +15,7 @@ class InMemoryStore(StateStore):
     """
 
     _store: dict[str, PRDState]
+    backend_name = "memory"
 
     def __init__(self) -> None:
         self._store = {}
@@ -26,3 +27,11 @@ class InMemoryStore(StateStore):
     async def get(self, run_id: str) -> PRDState | None:
         """Retrieves a PRD state from the in-memory dictionary."""
         return self._store.get(run_id)
+
+    async def ping(self) -> bool:
+        """The in-memory store is always ready for the current process."""
+        return True
+
+    async def close(self) -> None:
+        """Release in-memory resources."""
+        self._store.clear()

--- a/backend/state/redis_store.py
+++ b/backend/state/redis_store.py
@@ -1,6 +1,6 @@
 """State manager for reading and writing PRD state to Redis."""
 
-import os
+from inspect import isawaitable
 
 import redis
 import redis.asyncio as aredis
@@ -15,26 +15,18 @@ class RedisStore(StateStore):
     """
 
     _client: aredis.Redis
+    backend_name = "redis"
 
-    def __init__(self, redis_url: str | None = None):
+    def __init__(self, redis_url: str, ttl_seconds: int = 60 * 60 * 24 * 7):
         """
         Initializes the Redis client.
 
         Args:
-            redis_url: The connection URL for Redis. Defaults to the
-                       REDIS_URL environment variable or a local instance.
+            redis_url: The connection URL for Redis.
+            ttl_seconds: The retention period for saved run state.
         """
-        url = redis_url or os.getenv("REDIS_URL", "redis://localhost:6379/0")
-        if not url:
-            raise ValueError("Redis URL not provided.")
-        self._client = aredis.from_url(url, decode_responses=True)
-
-    async def connect(self) -> None:
-        """Connects to Redis and pings to check the connection."""
-        try:
-            await self._client.ping()
-        except redis.exceptions.ConnectionError as e:
-            raise ConnectionError("Could not connect to Redis.") from e
+        self._client = aredis.from_url(redis_url, decode_responses=True)
+        self._ttl_seconds = ttl_seconds
 
     def _get_key(self, run_id: str) -> str:
         """Generates the Redis key for a given run ID."""
@@ -47,8 +39,7 @@ class RedisStore(StateStore):
         The state is stored with a TTL of 7 days.
         """
         key = self._get_key(state.run_id)
-        # Pydantic's model_dump_json is used for serialization
-        await self._client.set(key, state.model_dump_json(), ex=60 * 60 * 24 * 7)
+        await self._client.set(key, state.model_dump_json(), ex=self._ttl_seconds)
 
     async def get(self, run_id: str) -> PRDState | None:
         """
@@ -58,5 +49,22 @@ class RedisStore(StateStore):
         data = await self._client.get(key)
         if not data:
             return None
-        # Pydantic's parse_raw is used for deserialization
-        return PRDState.parse_raw(data)
+        return PRDState.model_validate_json(data)
+
+    async def ping(self) -> bool:
+        """Check whether Redis is reachable."""
+        try:
+            return bool(await self._client.ping())
+        except redis.exceptions.RedisError:
+            return False
+
+    async def close(self) -> None:
+        """Close the Redis client cleanly."""
+        async_close = getattr(self._client, "aclose", None)
+        if callable(async_close):
+            await async_close()
+            return
+
+        close_result = self._client.close()
+        if isawaitable(close_result):
+            await close_result

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -17,12 +17,14 @@ RUN adduser --disabled-password --gecos '' appuser
 # Set work directory
 WORKDIR /app
 
-# Copy requirements and install Python dependencies
-COPY pyproject.toml ./
-RUN pip install -e ".[dev]"
+# Copy application metadata and runtime source
+COPY pyproject.toml README.md ./
+COPY backend ./backend
+COPY frontend ./frontend
+COPY agents ./agents
 
-# Copy application code
-COPY . .
+# Install runtime dependencies only
+RUN pip install .
 
 # Change ownership to appuser
 RUN chown -R appuser:appuser /app

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -12,12 +12,14 @@ RUN adduser --disabled-password --gecos '' appuser
 # Set work directory
 WORKDIR /app
 
-# Copy requirements and install Python dependencies
-COPY pyproject.toml ./
-RUN pip install -e ".[dev]"
+# Copy application metadata and runtime source
+COPY pyproject.toml README.md ./
+COPY backend ./backend
+COPY frontend ./frontend
+COPY agents ./agents
 
-# Copy application code
-COPY . .
+# Install runtime dependencies only
+RUN pip install .
 
 # Create .streamlit directory and config
 RUN mkdir -p /app/.streamlit

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,97 +1,45 @@
-# Project Requirement Document: Agentic PRD Generation
+# Product Requirements Document
 
-1. **Executive Summary**
-   - “Agentic PRD Generation” is a platform that automates the creation of high‑quality PRDs **and, in Phase 2, the accompanying Technical Specification** through an agentic loop (outline → draft → critique → revise). A real‑time front‑end visualises progress, helping developers and product managers turn ideas into structured, actionable plans quickly.
+## Summary
 
-2. **Success Metrics & Evaluation**
-   - **PRD Quality** – average rubric score ≥ 4/5 (clarity, completeness, coherence).
-   - **User Satisfaction** – CSAT ≥ 80 % or NPS ≥ 40 among pilot users.
-   - **Framework Insights** – qualitative comparison report produced in Phase B.
-   - **Tech Spec Completeness (Phase 2)** – generated spec passes an internal checklist (architecture, APIs, risks) with ≥ 90 % coverage.
+Agentic PRD Generation is an MVP that turns a single project idea into a structured PRD. The product emphasizes reliability and transparency over breadth: only implemented adapters and behaviors are exposed.
 
-3. **Functional Scope**
-   - **Input** – single high‑level project idea.
-   - **Agentic Workflow** – Outline → (optional) Research → Draft → Critique/Revise → **Generate Tech Spec**.
-   - **Framework Implementation**
-     - **Phase A (Required):** vanilla `openai` & `google-generativeai` clients.
-     - **Phase B (Optional/Pluggable):** `openai‑agents`, `CrewAI`, `AutoGen`, `smolagents`. Others (LangGraph, LangChain, LlamaIndex, DSPy) may be added after MVP.
-   - **Real‑Time UI** – display current step, full up‑to‑date PRD, diff history, and a **“Generate Tech Spec”** button.
-   - **Autonomy Levels** – Full vs. Supervised (user approvals at checkpoints).
+## Goals
 
-4. **Non‑Functional Requirements**
-   - **Performance** – end‑to‑end PRD generation ≤ 5 min on a standard project idea.
-   - **Reliability** – retry logic on LLM API errors; graceful degradation.
-   - **Usability** – intuitive UI, zero onboarding docs required.
-   - **Extensibility** – add new framework adapters with minimal refactor.
+- Produce a usable PRD draft with iterative outline, draft, critique, and revise stages.
+- Stream the latest run state to the UI in real time.
+- Keep local development and testing simple by working with either Redis or an in-memory fallback.
 
-5. **Solution Architecture**
+## In Scope
 
-   **5.1 Phase A — Vanilla Clients**
-   - FastAPI orchestrator.
-   - State in Redis (local dev fallback: in‑memory dict).
-   - Each agentic step is a **pure async function** that transforms an immutable `PRDState`; an async functional pipeline composes these steps end‑to‑end.
-   - Streaming via **Server‑Sent Events (SSE)**; `/stop` endpoint lets the UI cancel a run.
+- One `POST /api/v1/generate_prd` endpoint that accepts `idea` and `adapter`
+- One `GET /api/v1/stream/{run_id}` endpoint that replays the latest state and then streams future updates
+- Streamlit UI for entering an idea, selecting an implemented adapter, and following a live PRD run
+- Implemented adapters only: `vanilla_openai` and `vanilla_google`
 
-   **5.2 Phase B — Framework Adapters**
-   - One module per framework (`agents/crewai_adapter.py`, etc.).
-   - Strategy pattern selects the adapter; shared state & streaming layer remain untouched.
+## Out of Scope
 
-6. **Technology Stack**
+- Framework comparison adapters
+- Human-in-the-loop approval checkpoints
+- Stop or cancel controls
+- Tech spec generation
 
-   | Category | Required | Optional / Experimental |
-   |----------|----------|-------------------------|
-   | **Backend** | FastAPI (≥0.110), Python 3.11+ | – |
-   | **LLM Clients** | `openai`, `google-generativeai` | – |
-   | **Agentic Frameworks** | – | `openai‑agents`, `CrewAI`, `AutoGen`, `smolagents`, … |
-   | **Front‑end** | Streamlit (fastest to PoC) | Future React/Next.js port |
-   | **State / Streaming** | Redis + SSE | WebSocket upgrade if bidirectional control needed |
+## Functional Requirements
 
-7. **Agentic Workflow Spec**
+- A new run must persist an initial state immediately.
+- Each pipeline step must save a new immutable state with a truthful workflow step.
+- Provider failures must end the run with `step="Error"` and a separate `error` field.
+- SSE subscribers must receive the latest persisted state even if they connect late.
 
-   1. **Outline** – generate structured headings; exit when template matched.
-   2. **Research (Optional)** – targeted web search for ambiguous sections; exit on time or confidence threshold.
-   3. **Draft** – populate all sections.
-   4. **Critique & Revise Loop** – critique agent checks clarity/guardrails → revision agent fixes; repeat until no issues.
-   5. **Generate Tech Spec** – new agent consumes final PRD JSON, outputs architecture, APIs, risks.
-   - **Guardrails** – relevance checks, harmful‑content filter, user “stop” control.
+## Non-Functional Requirements
 
-8. **UI Wireframe Outline**
+- Local development must work without Redis by falling back to in-memory storage.
+- Health and readiness checks must reflect the actual backend state honestly.
+- The repo must keep passing `ruff`, `mypy`, and `pytest`.
 
-   - **Input Bar** – project idea, “Generate PRD” button.
-   - **Sidebar** – autonomy level radio buttons; framework selector.
-   - **Main Panel**
-     - **Status Banner** – current step (e.g., “Drafting…”).
-     - **Live PRD View** – markdown rendering auto‑refreshes.
-     - **Diff / Changelog** – collapsible.
-     - **Tech Spec Tab** (appears after PRD approval) – live stream of the spec.
-     - **Generate Tech Spec** button.
+## Acceptance Criteria
 
-9. **MVP Milestones & Timeline**
-
-   | Week | Deliverable |
-   |------|-------------|
-   | 1 | Repo scaffolding, FastAPI + Streamlit hello‑world, SSE pipeline mocked |
-   | 2 | Vanilla workflow with real OpenAI & Google clients |
-   | 3 | Live PRD diff viewer |
-   | 4 | First framework adapter (CrewAI) |
-   | 5 | Tech Spec generator + UI tab; decide whether to add more adapters |
-
-10. **Risks & Mitigations**
-
-   | Risk | Mitigation |
-   |------|------------|
-   | Inconsistent LLM output | Deterministic prompts, critique loop, temperature tuning |
-   | Scope creep from many frameworks | Limit Phase B to 1–2 adapters for MVP |
-   | State sync complexity | Start with Redis pub/sub; monitor latency before adding WebSockets |
-   | API cost overruns | Cache repeated calls, batch generations during research |
-
-11. **Acceptance‑Test Checklist**
-
-   - [ ] Submit idea → receive complete PRD.
-   - [ ] UI streams current workflow step in real time.
-   - [ ] PRD view updates after each revision; diff displayed.
-   - [ ] User can choose Phase A or a Phase B adapter.
-   - [ ] “Generate Tech Spec” button produces a spec streamed to UI.
-   - [ ] PRD passes quality rubric (≥ 4/5).
-   - [ ] Tech Spec covers architecture, APIs, risks (≥ 90 % checklist).
-   - [ ] Autonomy level setting correctly pauses for approvals.
+- Submitting an idea returns a `run_id`.
+- Refreshing or reconnecting to an active run replays the latest known state.
+- Failed provider calls do not produce fake successful completions.
+- The frontend only exposes shipped adapters and shipped behaviors.

--- a/docs/TECH_SPEC.md
+++ b/docs/TECH_SPEC.md
@@ -1,197 +1,100 @@
-# Technical Specification — Agentic‑PRD‑Generation
-*Version 0.1 • 2025‑07‑16*
+# Technical Specification
 
----
+## Architecture
 
-## 1  Purpose & Scope
-This document describes **how** we will implement the platform defined in [`docs/PRD.md`](PRD.md).
-It translates the *what/why* from the PRD into concrete architecture, APIs, data models, tooling, and quality attributes so any engineer can start coding with minimal ambiguity.
+- FastAPI application with lifespan-managed runtime resources
+- `AppSettings` loaded with `pydantic-settings`
+- Shared `StateStore` selected by configuration:
+  - `memory`: always use the in-memory store
+  - `redis`: require Redis to be reachable
+  - `auto`: use Redis when reachable, otherwise fall back to memory
+- Shared `StreamerService` that fans out updates to all subscribers for a run
+- Streamlit frontend that starts runs and listens for SSE updates without rerun-driven reconnects
 
----
+## Workflow
 
-## 2  High‑Level Architecture
+1. Persist an initial `Outline` state with the original idea.
+2. Generate outline content.
+3. Generate draft content.
+4. Run critique and revise iterations until approval or the revision limit is reached.
+5. Persist `Complete`, or `Error` when a provider call fails.
 
-```mermaid
-┌─────────────────────────────────────────────┐
-│                  Front‑end                  │
-│  Streamlit UI                               │
-│  ├─ Input bar                               │
-│  ├─ Status banner (SSE)                     │
-│  ├─ Live PRD viewer                         │
-│  └─ Diff / Tech‑Spec tab                    │
-└───────────────▲───────────────▲─────────────┘
-│ SSE/WebSocket │
-│               │
-┌───────────────┴───────────────┴─────────────┐
-│                 FastAPI API                 │
-│  /generate_prd  /stop  /generate_spec       │
-│  ├─ Orchestrator service                    │
-│  ├─ Agent adapters (strategy pattern)       │
-│  └─ State manager (Redis)                   │
-└───────────────▲───────────────▲─────────────┘
-│ Async calls   │
-│               │
-┌──────────┴──────────┐   ┌┴────────────┐
-│ OpenAI client (vA)  │   │ Google‑GenAI│
-└─────────────────────┘   └─────────────┘
+## Public API
+
+### `POST /api/v1/generate_prd`
+
+Request body:
+
+```json
+{
+  "idea": "AI project idea",
+  "adapter": "vanilla_openai"
+}
 ```
 
-*A PNG/SVG version will be committed to `docs/diagrams/architecture_v1.png`.*
+Supported adapters:
 
----
+- `vanilla_openai`
+- `vanilla_google`
 
-## 3  Component Design
+Response body:
 
-| ID | Component | Responsibilities | Key Classes / Files |
-|----|-----------|------------------|---------------------|
-| **C1** | **Front‑end** | Render UI, open SSE channel, send user commands | `frontend/app.py`, `components/*` |
-| **C2** | **API Gateway** | FastAPI routes, auth middleware | `backend/routes/*.py` |
-| **C3** | **Pipeline Runner** | Functional async pipeline (`generate_outline` → `draft` → `critique` → `revise`); emits state events | `backend/pipelines/pipeline_runner.py` |
-| **C4** | **Adapter Protocol** | Defines a single `call_llm()` function consumed by the pipeline        | `backend/agents/base_adapter.py`              |
-| **C5** | **Adapter (Vanilla)** | Implements `call_llm` using OpenAI & Google clients                   | `backend/agents/vanilla.py`                   |
-| **C6** | **Adapter (CrewAI)** | Wraps CrewAI workflow; adheres to C4 | `backend/agents/crewai_adapter.py` |
-| **C7** | **State Manager** | Read/write PRD JSON, revision diff, progress | `backend/state/redis_store.py` |
-| **C8** | **Streaming Service** | Push state deltas via SSE; optional WebSocket upgrade | `backend/services/streamer.py` |
-
----
-
-## 4  Public API (FastAPI)
-
-| Verb | Path | Payload | Response | Notes |
-|------|------|---------|----------|-------|
-| `POST` | `/generate_prd` | `{idea, autonomy, adapter}` | `{run_id}` | Starts Phase A/B run |
-| `POST` | `/stop` | `{run_id}` | `202 Accepted` | Graceful cancel |
-| `POST` | `/generate_spec` | `{run_id}` | `{spec_run_id}` | Triggers Tech Spec agent |
-| `GET` | `/stream/{run_id}` | — | `text/event‑stream` | Emits JSON events: `{"step":"Draft","delta":"…"}"` |
-
----
-
-## 5  Data Models
-
-```python
-class PRDState(BaseModel, frozen=True):
-    run_id: str
-    step: Literal["Outline", "Research", "Draft", "Critique", "Revise", "Complete"]
-    content: str  # full markdown
-    revision: int
-    diff: str | None  # unified diff vs. previous rev
-    created_at: datetime
+```json
+{
+  "run_id": "uuid"
+}
 ```
 
-*Redis key:* `prd:{run_id}`
-*TTL:* 7 days (configurable).
+### `GET /api/v1/stream/{run_id}`
 
----
+- Replays the latest persisted state first
+- Streams future run updates as SSE `message` events
 
-## 6  Agent Interface
+Event payload:
 
-```python
-from typing import Protocol
-
-
-class BaseAdapter(Protocol):
-    async def call_llm(self, prompt: str) -> str: ...
+```json
+{
+  "run_id": "uuid",
+  "step": "Draft",
+  "content": "# PRD ...",
+  "revision": 2,
+  "diff": "@@ ...",
+  "error": null,
+  "created_at": "2026-03-10T12:00:00Z"
+}
 ```
 
-All adapters (**vanilla, CrewAI, AutoGen…**) must:
+### `GET /health`
 
-* Implement the same coroutine methods.
-* Emit `state_manager.save()` after each step.
-* Respect `self.cancelled` flag (set by `/stop`).
+- Lightweight liveness probe
 
----
+### `GET /ready`
 
-## 7  Technology & Dependencies
+- Reports readiness for the selected state backend
 
-| Layer  | Library                                       | Pin      |
-| ------ | --------------------------------------------- | -------- |
-| API    | `fastapi`                                     | `^0.110` |
-| LLM    | `openai` ≥ 1.14 • `google-generativeai` ≥ 0.5 |          |
-| Stream | `sse-starlette`                               |          |
-| State  | `redis[p asyncio]`                            |          |
-| UI     | `streamlit` ≥ 1.34                            |          |
-| Dev    | `uvicorn`, `pytest`, `ruff`, `pre-commit`     |          |
+## Data Model
 
----
+Persisted run state includes:
 
-## 8  Environment Variables
+- `run_id`
+- `idea`
+- `step`
+- `content`
+- `revision`
+- `diff`
+- `error`
+- `created_at`
 
-```env
-OPENAI_API_KEY=...
-GOOGLE_API_KEY=...
-REDIS_URL=redis://localhost:6379/0
-AGENTIC_ADAPTER=vanilla_openai     # default
-```
+The original `idea` is stored for pipeline correctness but omitted from the public SSE payload.
 
-Secrets stored in GitHub Actions + `.env.example` for local dev.
+## Operational Notes
 
----
+- OpenAI calls use the official `openai` SDK.
+- Google calls use the supported `google-genai` SDK.
+- Structured logging is emitted with step, adapter, run id, and outcome metadata.
 
-## 9  Quality Attributes & Targets
+## Test Strategy
 
-| Attribute         | Target                        | Mechanism                                              |
-| ----------------- | ----------------------------- | ------------------------------------------------------ |
-| **Performance**   | PRD ≤ 5 min (95‑th pct)       | Async I/O, batching research calls                     |
-| **Reliability**   | 99.5 % successful runs        | Retry w/ exponential back‑off, idempotent state writes |
-| **Usability**     | Zero‑doc onboarding           | Inline hints, sane defaults                            |
-| **Observability** | Trace each LLM call & latency | OpenTelemetry + console exporter (MVP)                 |
-| **Security**      | No secrets in logs            | Pydantic redaction, HTTPS only                         |
-
----
-
-## 10  Testing Strategy
-
-| Layer       | Tool                        | Coverage                  |
-| ----------- | --------------------------- | ------------------------- |
-| Unit        | `pytest` + `pytest‑asyncio` | ≥ 80 %                    |
-| Integration | Local Redis + mock LLMs     | agent loop end‑to‑end     |
-| Contract    | `schemathesis` on `/stream` | SSE schema                |
-| LLM Quality | rubric scorer agent         | PRD score automated in CI |
-
----
-
-## 11  Deployment & CI/CD
-
-* **CI** – GitHub Actions (`ci.yml`): lint ➜ unit tests ➜ upload coverage badge.
-* **Preview** – Streamlit Community Cloud on every `main` push.
-* **Prod candidate** – Docker Compose (`docker-compose.yml`) with FastAPI, Redis, Nginx.
-
----
-
-## 12  Risks & Mitigations
-
-| Risk                | Probability | Impact | Mitigation                        |
-| ------------------- | ----------- | ------ | --------------------------------- |
-| LLM API cost spike  | M           | H      | caching, temperature ≤ 0.7        |
-| Redis single point  | L           | M      | allow env swap to AWS Elasticache |
-| Framework API drift | M           | M      | pin versions, weekly Dependabot   |
-
----
-
-## 13  Glossary
-
-| Term        | Meaning                                                            |
-| ----------- | ------------------------------------------------------------------ |
-| **Agent**   | Autonomous loop that reasons → acts → writes state                 |
-| **Adapter** | Wrapper that maps a third‑party agent framework to our `BaseAgent` |
-| **Run ID**  | UUID for one PRD or Tech‑Spec generation session                   |
-
----
-
-## 14  Acceptance Criteria (Tech Spec)
-
-* [ ] All components described above exist as code stubs.
-* [ ] `uvicorn backend.main:app` starts with no errors.
-* [ ] `/generate_prd` returns `run_id`; `/stream/{run_id}` streams hello‑world events.
-* [ ] Vanilla adapter completes full loop with mocked LLMs.
-* [ ] CI passes on a clean clone (`make ci`).
-
----
-
-## 15  Sign‑off
-
-| Role         | Name  | Date | Signature |
-| ------------ | ----- | ---- | --------- |
-| Product Lead | *TBD* |      |           |
-| Tech Lead    | *TBD* |      |           |
-| QA Lead      | *TBD* |      |           |
+- Unit tests cover runtime selection, pipeline transitions, streamer fan-out, frontend helpers, and CLI wiring.
+- Integration tests cover `POST /generate_prd` plus late-subscriber SSE replay.
+- CI keeps `ruff`, `mypy`, and `pytest` as baseline gates.

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -159,15 +159,13 @@ def listen_for_updates(
                     st.session_state.stream_active = False
                     return
     except httpx.HTTPStatusError as exc:
-        st.session_state.status = "Error"
-        st.session_state.error = (
+        mark_stream_error(
             f"Stream connection failed with status {exc.response.status_code}."
         )
     except httpx.RequestError as exc:
-        st.session_state.error = f"Stream request failed: {exc}"
+        mark_stream_error(f"Stream request failed: {exc}")
     except Exception as exc:  # pragma: no cover - defensive UI fallback
-        st.session_state.status = "Error"
-        st.session_state.error = f"Stream disconnected unexpectedly: {exc}"
+        mark_stream_error(f"Stream disconnected unexpectedly: {exc}")
     finally:
         st.session_state.stream_active = False
         render_state(
@@ -185,6 +183,12 @@ def update_state(data: dict[str, Any]) -> None:
     st.session_state.prd_content = ui_state["prd_content"]
     st.session_state.diff = ui_state["diff"]
     st.session_state.error = ui_state["error"]
+
+
+def mark_stream_error(message: str) -> None:
+    """Put the UI in a terminal error state after stream failures."""
+    st.session_state.status = "Error"
+    st.session_state.error = message
 
 
 def build_generation_payload(idea: str, adapter: str) -> dict[str, str]:

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,16 +1,16 @@
-"""
-Streamlit frontend application for Agentic PRD Generation.
-
-This is the main entry point for the web UI that allows users to
-generate PRDs and Technical Specifications through an agentic workflow.
-"""
+"""Streamlit frontend application for Agentic PRD Generation."""
 
 import json
 import os
+from typing import Any
 
 import httpx
 from httpx_sse import connect_sse
 import streamlit as st
+
+DEFAULT_PRD_CONTENT = "*Your generated PRD will appear here.*"
+TERMINAL_STEPS = {"Complete", "Error"}
+IMPLEMENTED_ADAPTERS = ["vanilla_openai", "vanilla_google"]
 
 
 def main() -> None:
@@ -22,39 +22,20 @@ def main() -> None:
         initial_sidebar_state="expanded",
     )
 
+    initialize_session_state()
+
     st.title("🛠️ Agentic PRD Generation")
-    st.markdown(
-        "*AI-powered platform for iterative PRD and Technical Specification generation*"
-    )
+    st.markdown("*AI-powered platform for iterative PRD generation*")
 
-    # Initialize session state
-    if "run_id" not in st.session_state:
-        st.session_state.run_id = None
-    if "prd_content" not in st.session_state:
-        st.session_state.prd_content = "*Your generated PRD will appear here.*"
-    if "status" not in st.session_state:
-        st.session_state.status = "Idle"
-    if "diff" not in st.session_state:
-        st.session_state.diff = ""
-
-    # --- UI Layout ---
-
-    # Sidebar configuration
     with st.sidebar:
         st.header("Configuration")
-        st.selectbox("Autonomy Level", ["Full", "Supervised"], key="autonomy_level")
-        st.selectbox(
-            "Adapter",
-            ["vanilla_openai", "vanilla_google", "crewai"],
-            key="adapter",
-        )
+        st.selectbox("Adapter", IMPLEMENTED_ADAPTERS, key="adapter")
         st.text_input(
             "Backend API URL",
             value=os.getenv("BACKEND_URL", "http://localhost:8000"),
             key="api_url",
         )
 
-    # Main content area
     col1, col2 = st.columns([2, 1])
 
     with col1:
@@ -65,81 +46,210 @@ def main() -> None:
             height=100,
             key="project_idea",
         )
-
-        if st.button("Generate PRD", type="primary"):
-            if not st.session_state.project_idea:
+        if st.button(
+            "Generate PRD",
+            type="primary",
+            disabled=st.session_state.stream_active,
+        ):
+            if not st.session_state.project_idea.strip():
                 st.error("Please enter a project idea.")
             else:
                 start_generation()
+        prd_placeholder = st.empty()
 
+    with col2:
+        status_placeholder = st.empty()
+        error_placeholder = st.empty()
+        diff_placeholder = st.empty()
+
+    render_state(
+        prd_placeholder=prd_placeholder,
+        status_placeholder=status_placeholder,
+        diff_placeholder=diff_placeholder,
+        error_placeholder=error_placeholder,
+    )
+
+    if should_resume_stream():
+        listen_for_updates(
+            prd_placeholder=prd_placeholder,
+            status_placeholder=status_placeholder,
+            diff_placeholder=diff_placeholder,
+            error_placeholder=error_placeholder,
+        )
+
+
+def initialize_session_state() -> None:
+    """Seed Streamlit session state defaults."""
+    defaults: dict[str, Any] = {
+        "run_id": None,
+        "prd_content": DEFAULT_PRD_CONTENT,
+        "status": "Idle",
+        "diff": "",
+        "error": None,
+        "stream_active": False,
+        "project_idea": "",
+        "adapter": IMPLEMENTED_ADAPTERS[0],
+    }
+    for key, value in defaults.items():
+        if key not in st.session_state:
+            st.session_state[key] = value
+
+
+def start_generation() -> None:
+    """Initiate the PRD generation process."""
+    payload = build_generation_payload(
+        idea=st.session_state.project_idea,
+        adapter=st.session_state.adapter,
+    )
+
+    try:
+        with httpx.Client() as client:
+            response = client.post(
+                f"{st.session_state.api_url}/api/v1/generate_prd",
+                json=payload,
+            )
+            response.raise_for_status()
+        data = response.json()
+        st.session_state.run_id = data["run_id"]
+        st.session_state.status = "Outline"
+        st.session_state.prd_content = (
+            f"# PRD for {payload['idea']}\n\n_Starting outline generation..._"
+        )
+        st.session_state.diff = ""
+        st.session_state.error = None
+        st.session_state.stream_active = True
+    except httpx.RequestError as exc:
+        st.session_state.stream_active = False
+        st.error(f"Could not connect to backend: {exc}")
+    except httpx.HTTPStatusError as exc:
+        st.session_state.stream_active = False
+        st.error(
+            f"Error from backend: {exc.response.status_code} - {exc.response.text}"
+        )
+
+
+def listen_for_updates(
+    *,
+    prd_placeholder: Any,
+    status_placeholder: Any,
+    diff_placeholder: Any,
+    error_placeholder: Any,
+) -> None:
+    """Connect to the SSE stream and update the UI in-place."""
+    if not st.session_state.run_id:
+        return
+
+    st.session_state.stream_active = True
+    url = build_stream_url(st.session_state.api_url, st.session_state.run_id)
+    timeout = httpx.Timeout(timeout=None, connect=5.0)
+
+    try:
+        with connect_sse(httpx.Client(timeout=timeout), "GET", url) as event_source:
+            for sse in event_source.iter_sse():
+                if sse.event != "message":
+                    continue
+                update_state(json.loads(sse.data))
+                render_state(
+                    prd_placeholder=prd_placeholder,
+                    status_placeholder=status_placeholder,
+                    diff_placeholder=diff_placeholder,
+                    error_placeholder=error_placeholder,
+                )
+                if is_terminal_step(st.session_state.status):
+                    st.session_state.stream_active = False
+                    return
+    except httpx.HTTPStatusError as exc:
+        st.session_state.status = "Error"
+        st.session_state.error = (
+            f"Stream connection failed with status {exc.response.status_code}."
+        )
+    except httpx.RequestError as exc:
+        st.session_state.error = f"Stream request failed: {exc}"
+    except Exception as exc:  # pragma: no cover - defensive UI fallback
+        st.session_state.status = "Error"
+        st.session_state.error = f"Stream disconnected unexpectedly: {exc}"
+    finally:
+        st.session_state.stream_active = False
+        render_state(
+            prd_placeholder=prd_placeholder,
+            status_placeholder=status_placeholder,
+            diff_placeholder=diff_placeholder,
+            error_placeholder=error_placeholder,
+        )
+
+
+def update_state(data: dict[str, Any]) -> None:
+    """Update session state with data from the stream."""
+    ui_state = coerce_stream_state(data)
+    st.session_state.status = ui_state["status"]
+    st.session_state.prd_content = ui_state["prd_content"]
+    st.session_state.diff = ui_state["diff"]
+    st.session_state.error = ui_state["error"]
+
+
+def build_generation_payload(idea: str, adapter: str) -> dict[str, str]:
+    """Create the backend payload for a new PRD run."""
+    return {"idea": idea.strip(), "adapter": adapter}
+
+
+def build_stream_url(api_url: str, run_id: str) -> str:
+    """Build the SSE URL for a run."""
+    return f"{api_url}/api/v1/stream/{run_id}"
+
+
+def is_terminal_step(step: str) -> bool:
+    """Return whether a workflow step is terminal."""
+    return step in TERMINAL_STEPS
+
+
+def should_resume_stream() -> bool:
+    """Return whether the current session should keep listening for updates."""
+    return bool(st.session_state.run_id) and not is_terminal_step(
+        st.session_state.status
+    )
+
+
+def coerce_stream_state(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a raw stream event into UI state."""
+    return {
+        "status": data.get("step", "Unknown"),
+        "prd_content": data.get("content", DEFAULT_PRD_CONTENT),
+        "diff": data.get("diff", "") or "",
+        "error": data.get("error"),
+    }
+
+
+def render_state(
+    *,
+    prd_placeholder: Any,
+    status_placeholder: Any,
+    diff_placeholder: Any,
+    error_placeholder: Any,
+) -> None:
+    """Render the current session state into placeholder containers."""
+    with prd_placeholder.container():
         st.header("Live PRD")
         st.markdown(st.session_state.prd_content)
 
-    with col2:
+    with status_placeholder.container():
         st.header("Status")
         st.info(f"**Workflow Step:** {st.session_state.status}")
 
+    if st.session_state.error:
+        with error_placeholder.container():
+            st.error(st.session_state.error)
+    elif st.session_state.status == "Complete":
+        with error_placeholder.container():
+            st.success("PRD generation completed.")
+    else:
+        error_placeholder.empty()
+
+    with diff_placeholder.container():
         st.header("Revision Diff")
         if st.session_state.diff:
             st.code(st.session_state.diff, language="diff")
         else:
             st.info("*No diff available yet.*")
-
-
-def start_generation() -> None:
-    """Initiates the PRD generation process."""
-    api_url = st.session_state.api_url
-    payload = {
-        "idea": st.session_state.project_idea,
-        "autonomy_level": st.session_state.autonomy_level,
-        "adapter": st.session_state.adapter,
-    }
-
-    try:
-        print(f"Sending payload to backend: {payload}")  # Diagnostic print
-        with httpx.Client() as client:
-            response = client.post(f"{api_url}/api/v1/generate_prd", json=payload)
-            response.raise_for_status()
-            data = response.json()
-            st.session_state.run_id = data["run_id"]
-            st.session_state.status = "Starting..."
-            listen_for_updates()
-    except httpx.RequestError as e:
-        st.error(f"Could not connect to backend: {e}")
-    except httpx.HTTPStatusError as e:
-        st.error(f"Error from backend: {e.response.status_code} - {e.response.text}")
-
-
-def listen_for_updates() -> None:
-    """Connects to the SSE stream and updates the UI."""
-    if not st.session_state.run_id:
-        return
-
-    api_url = st.session_state.api_url
-    run_id = st.session_state.run_id
-    url = f"{api_url}/api/v1/stream/{run_id}"
-
-    try:
-        with connect_sse(httpx.Client(), "GET", url) as event_source:
-            st.info(f"Connected to stream for run ID: {run_id}")
-            for sse in event_source.iter_sse():
-                if sse.event == "message":
-                    update_state(json.loads(sse.data))
-                    st.rerun()  # Rerun to update the UI
-    except httpx.HTTPStatusError as e:
-        st.error(f"Error connecting to stream: {e.response.status_code}")
-        st.session_state.status = "Error"
-    except Exception as e:
-        st.warning(f"Stream disconnected: {e}")
-        if st.session_state.status not in ("Complete", "Error"):
-            st.session_state.status = "Finished"
-
-
-def update_state(data: dict) -> None:
-    """Updates the session state with data from the stream."""
-    st.session_state.status = data.get("step", "Unknown")
-    st.session_state.prd_content = data.get("content", "*No content received.*")
-    st.session_state.diff = data.get("diff", "")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agentic-prd-generation"
 version = "0.1.0"
-description = "AI-powered platform for iterative PRD and Technical Specification generation"
+description = "AI-powered platform for iterative PRD generation"
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [
     {name = "Agentic PRD Generation Team"},
 ]
-keywords = ["ai", "prd", "technical-spec", "agents", "llm"]
+keywords = ["ai", "prd", "product-requirements", "llm"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -32,7 +32,7 @@ dependencies = [
 
     # LLM clients
     "openai>=1.14.0",
-    "google-generativeai>=0.5.0",
+    "google-genai>=1.0.0",
 
     # State management
     "redis[hiredis]>=5.0.0",
@@ -47,7 +47,6 @@ dependencies = [
 
     # Async support
     "httpx>=0.27.0",
-    "aioredis>=2.0.0",
 
     # Utilities
     "python-multipart>=0.0.9",
@@ -65,7 +64,6 @@ dev = [
     # Code quality
     "ruff>=0.3.0",
     "mypy>=1.9.0",
-    "pydantic[mypy]>=2.6.0",
     "pre-commit>=3.6.0",
     "types-redis>=4.6.0",
     "types-requests>=2.31.0",
@@ -79,7 +77,6 @@ dev = [
 
     # Development tools
     "ipython>=8.22.0",
-    "jupyterlab>=4.1.0",
 ]
 
 test = [
@@ -106,10 +103,10 @@ observability = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/your-org/agentic-prd-generation"
-Repository = "https://github.com/your-org/agentic-prd-generation"
-Documentation = "https://github.com/your-org/agentic-prd-generation/blob/main/docs/"
-"Bug Tracker" = "https://github.com/your-org/agentic-prd-generation/issues"
+Homepage = "https://github.com/SeeknnDestroy/agentic-prd-generation"
+Repository = "https://github.com/SeeknnDestroy/agentic-prd-generation"
+Documentation = "https://github.com/SeeknnDestroy/agentic-prd-generation/tree/main/docs"
+"Bug Tracker" = "https://github.com/SeeknnDestroy/agentic-prd-generation/issues"
 
 [project.scripts]
 agentic-prd = "backend.main:cli"
@@ -174,6 +171,7 @@ module = [
     "streamlit.*",
     "redis.*",
     "sse_starlette.*",
+    "google.genai.*",
     "crewai.*",
     "autogen.*",
     "smolagents.*",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,30 +1,35 @@
 """Pytest configuration and shared fixtures."""
 
-import asyncio
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import Generator
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import pytest
 
-from backend.main import app
+from backend.main import create_app
+from backend.settings import AppSettings
 
 
 @pytest.fixture(scope="session")
-def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
-    """Create an event loop for the test session."""
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
+def test_settings() -> AppSettings:
+    """Stable settings for local tests."""
+    return AppSettings(
+        environment="test",
+        debug=True,
+        state_backend="memory",
+        openai_api_key="test-openai-key",
+        google_api_key="test-google-key",
+    )
 
 
 @pytest.fixture
-def client() -> TestClient:
-    """FastAPI test client."""
-    return TestClient(app)
+def app(test_settings: AppSettings) -> FastAPI:
+    """Create a fresh FastAPI app for each test."""
+    return create_app(test_settings)
 
 
 @pytest.fixture
-async def async_client() -> AsyncGenerator[TestClient, None]:
-    """Async FastAPI test client."""
-    async with TestClient(app) as client:
-        yield client
+def client(app: FastAPI) -> Generator[TestClient, None, None]:
+    """FastAPI test client with lifespan support enabled."""
+    with TestClient(app) as test_client:
+        yield test_client

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -1,0 +1,81 @@
+"""Integration tests for generation and streaming."""
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+from sse_starlette.sse import EventSourceResponse
+
+from backend.routes.generation import stream_prd
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+async def _read_first_sse_event(
+    response: EventSourceResponse,
+) -> dict[str, object]:
+    """Read the first payload from an SSE response body iterator."""
+    iterator = cast("AsyncIterator[dict[str, object]]", response.body_iterator)
+    message = await anext(iterator)
+    data = cast("str", message["data"])
+    return cast("dict[str, object]", json.loads(data))
+
+
+@patch("backend.routes.generation.run_pipeline", new_callable=AsyncMock)
+def test_generate_prd_stream_replays_latest_state(
+    mock_run_pipeline: AsyncMock,
+    client: TestClient,
+) -> None:
+    """A subscriber should immediately receive the latest persisted run state."""
+    response = client.post(
+        "/api/v1/generate_prd",
+        json={"idea": "A PRD assistant", "adapter": "vanilla_openai"},
+    )
+    assert response.status_code == 201
+
+    run_id = response.json()["run_id"]
+    runtime = client.app.state.runtime  # type: ignore[attr-defined]
+    stream_response = asyncio.run(
+        stream_prd(run_id, runtime.state_store, runtime.streamer)
+    )
+    payload = asyncio.run(_read_first_sse_event(stream_response))
+
+    assert payload["run_id"] == run_id
+    assert payload["step"] == "Outline"
+    assert payload["error"] is None
+    mock_run_pipeline.assert_awaited_once()
+
+
+@patch("backend.routes.generation.run_pipeline", new_callable=AsyncMock)
+def test_stream_replays_terminal_error_state(
+    mock_run_pipeline: AsyncMock,
+    client: TestClient,
+) -> None:
+    """Late subscribers should see terminal error state replay."""
+    response = client.post(
+        "/api/v1/generate_prd",
+        json={"idea": "Broken run", "adapter": "vanilla_openai"},
+    )
+    run_id = response.json()["run_id"]
+    runtime = client.app.state.runtime  # type: ignore[attr-defined]
+    latest_state = asyncio.run(runtime.state_store.get(run_id))
+    assert latest_state is not None
+
+    asyncio.run(
+        runtime.state_store.save(
+            latest_state.model_copy(
+                update={"step": "Error", "revision": 1, "error": "boom"}
+            )
+        )
+    )
+    stream_response = asyncio.run(
+        stream_prd(run_id, runtime.state_store, runtime.streamer)
+    )
+    payload = asyncio.run(_read_first_sse_event(stream_response))
+
+    assert payload["step"] == "Error"
+    assert payload["error"] == "boom"
+    mock_run_pipeline.assert_awaited_once()

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -24,6 +24,16 @@ async def _read_first_sse_event(
     return cast("dict[str, object]", json.loads(data))
 
 
+async def _stream_is_exhausted(response: EventSourceResponse) -> bool:
+    """Return whether the SSE body iterator terminates after the first event."""
+    iterator = cast("AsyncIterator[dict[str, object]]", response.body_iterator)
+    try:
+        await anext(iterator)
+    except StopAsyncIteration:
+        return True
+    return False
+
+
 @patch("backend.routes.generation.run_pipeline", new_callable=AsyncMock)
 def test_generate_prd_stream_replays_latest_state(
     mock_run_pipeline: AsyncMock,
@@ -78,4 +88,5 @@ def test_stream_replays_terminal_error_state(
 
     assert payload["step"] == "Error"
     assert payload["error"] == "boom"
+    assert asyncio.run(_stream_is_exhausted(stream_response)) is True
     mock_run_pipeline.assert_awaited_once()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,19 @@
+"""Unit tests for the CLI entrypoint."""
+
+from unittest.mock import patch
+
+from backend.main import cli
+
+
+def test_cli_invokes_uvicorn_with_expected_arguments() -> None:
+    """The console entrypoint should delegate to Uvicorn."""
+    with patch("backend.main.uvicorn.run") as mock_run:
+        exit_code = cli(["--host", "127.0.0.1", "--port", "9001", "--no-reload"])
+
+    assert exit_code == 0
+    mock_run.assert_called_once_with(
+        "backend.main:app",
+        host="127.0.0.1",
+        port=9001,
+        reload=False,
+    )

--- a/tests/unit/test_frontend.py
+++ b/tests/unit/test_frontend.py
@@ -1,11 +1,14 @@
 """Unit tests for frontend helper functions."""
 
+import streamlit as st
+
 from frontend.app import (
     DEFAULT_PRD_CONTENT,
     build_generation_payload,
     build_stream_url,
     coerce_stream_state,
     is_terminal_step,
+    mark_stream_error,
 )
 
 
@@ -37,3 +40,14 @@ def test_coerce_stream_state_defaults() -> None:
         "diff": "",
         "error": None,
     }
+
+
+def test_mark_stream_error_sets_terminal_state() -> None:
+    """Transport failures should move the UI to a terminal error state."""
+    st.session_state.status = "Draft"
+    st.session_state.error = None
+
+    mark_stream_error("backend unavailable")
+
+    assert st.session_state.status == "Error"
+    assert st.session_state.error == "backend unavailable"

--- a/tests/unit/test_frontend.py
+++ b/tests/unit/test_frontend.py
@@ -1,0 +1,39 @@
+"""Unit tests for frontend helper functions."""
+
+from frontend.app import (
+    DEFAULT_PRD_CONTENT,
+    build_generation_payload,
+    build_stream_url,
+    coerce_stream_state,
+    is_terminal_step,
+)
+
+
+def test_build_generation_payload_trims_idea() -> None:
+    """Payload building should trim leading and trailing whitespace."""
+    payload = build_generation_payload("  test idea  ", "vanilla_openai")
+    assert payload == {"idea": "test idea", "adapter": "vanilla_openai"}
+
+
+def test_build_stream_url() -> None:
+    """The stream URL should be derived from the backend base URL."""
+    assert build_stream_url("http://localhost:8000", "run-1") == (
+        "http://localhost:8000/api/v1/stream/run-1"
+    )
+
+
+def test_is_terminal_step() -> None:
+    """Only terminal run states should return true."""
+    assert is_terminal_step("Complete")
+    assert is_terminal_step("Error")
+    assert not is_terminal_step("Draft")
+
+
+def test_coerce_stream_state_defaults() -> None:
+    """Missing event fields should fall back to safe UI defaults."""
+    assert coerce_stream_state({}) == {
+        "status": "Unknown",
+        "prd_content": DEFAULT_PRD_CONTENT,
+        "diff": "",
+        "error": None,
+    }

--- a/tests/unit/test_generation.py
+++ b/tests/unit/test_generation.py
@@ -1,23 +1,23 @@
 """Unit tests for the generation API endpoints."""
 
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import pytest
 
 from backend.agents.base_adapter import BaseAdapter
-from backend.main import app
+from backend.dependencies import get_agent_adapter, get_state_store
 from backend.models import PRDState
-from backend.routes.generation import get_agent_adapter, get_state_store
 from backend.state.base import StateStore
 
 
-def is_valid_uuid(val: str) -> bool:
+def is_valid_uuid(value: str) -> bool:
     """Check if a string is a valid UUID."""
     try:
-        uuid.UUID(str(val))
+        uuid.UUID(str(value))
         return True
     except ValueError:
         return False
@@ -25,101 +25,67 @@ def is_valid_uuid(val: str) -> bool:
 
 @pytest.fixture
 def client_with_mocks(
+    app: FastAPI,
     client: TestClient,
 ) -> Generator[tuple[TestClient, MagicMock, MagicMock], None, None]:
-    """
-    Pytest fixture to provide a TestClient with mocked dependencies for
-    the generation routes. It also handles cleanup of dependency overrides.
-    """
+    """Provide a client with mocked generation dependencies."""
     mock_state_store = MagicMock(spec=StateStore)
     mock_agent_adapter = MagicMock(spec=BaseAdapter)
-    mock_agent_adapter.call_llm.return_value = "Mocked LLM response"
 
     app.dependency_overrides[get_state_store] = lambda: mock_state_store
     app.dependency_overrides[get_agent_adapter] = lambda: mock_agent_adapter
 
     yield client, mock_state_store, mock_agent_adapter
 
-    # Clean up the overrides after the test
     app.dependency_overrides = {}
 
 
-@patch("backend.routes.generation.run_pipeline")
+@patch("backend.routes.generation.run_pipeline", new_callable=AsyncMock)
 def test_generate_prd_success(
-    mock_run_pipeline: MagicMock,
+    mock_run_pipeline: AsyncMock,
     client_with_mocks: tuple[TestClient, MagicMock, MagicMock],
 ) -> None:
-    """
-    Test that the /generate_prd endpoint returns a 201 status, a valid
-    run_id, and correctly saves the initial state. The pipeline itself is mocked.
-    """
+    """`POST /generate_prd` returns a run id and saves the initial state."""
     client, mock_state_store, _ = client_with_mocks
-    idea = "A new project management tool"
 
     response = client.post(
         "/api/v1/generate_prd",
-        json={"idea": idea, "adapter": "vanilla_openai"},
+        json={"idea": "A new project management tool", "adapter": "vanilla_openai"},
     )
 
     assert response.status_code == 201
-    data = response.json()
-    run_id = data["run_id"]
+    run_id = response.json()["run_id"]
     assert is_valid_uuid(run_id)
 
-    # Verify that the state store's save method was called once for the initial state
     mock_state_store.save.assert_called_once()
-    saved_state = mock_state_store.save.call_args[0][0]
+    saved_state = mock_state_store.save.call_args.args[0]
     assert isinstance(saved_state, PRDState)
     assert saved_state.run_id == run_id
+    assert saved_state.idea == "A new project management tool"
     assert saved_state.step == "Outline"
+    assert saved_state.error is None
 
-    # Verify that the pipeline was called in the background
-    mock_run_pipeline.assert_called_once()
+    mock_run_pipeline.assert_awaited_once()
 
 
-def test_generate_prd_for_unimplemented_adapter(client: TestClient) -> None:
-    """
-    Test that requesting an adapter that is not yet implemented returns a
-    501 Not Implemented error.
-    """
-    # Ensure no overrides from other tests are present
-    app.dependency_overrides = {}
+def test_generate_prd_validation_errors(
+    client: TestClient,
+) -> None:
+    """The route validates the narrowed request contract."""
+    response = client.post("/api/v1/generate_prd", json={})
+    assert response.status_code == 422
+    assert "Field required" in str(response.json()["detail"])
+
+    response = client.post(
+        "/api/v1/generate_prd", json={"idea": "", "adapter": "vanilla_openai"}
+    )
+    assert response.status_code == 422
+    assert "at least 1 character" in str(response.json()["detail"])
+
     response = client.post(
         "/api/v1/generate_prd",
-        json={
-            "idea": "A new social media platform for cats",
-            "adapter": "crewai",
-        },
+        json={"idea": "Valid idea", "adapter": "invalid_adapter"},
     )
-    assert response.status_code == 501
-    data = response.json()
-    assert "adapter is not yet available" in data["detail"]
-
-
-@pytest.mark.parametrize(
-    "payload, expected_msg",
-    [
-        ({}, "Field required"),
-        ({"idea": ""}, "String should have at least 1 character"),
-        (
-            {"idea": "Valid idea", "autonomy_level": "Invalid"},
-            "Input should be 'Full' or 'Supervised'",
-        ),
-        (
-            {"idea": "Valid idea", "adapter": "invalid_adapter"},
-            "Input should be 'vanilla_openai', 'vanilla_google' or 'crewai'",
-        ),
-    ],
-)
-def test_generate_prd_validation_errors(
-    client: TestClient, payload: dict, expected_msg: str
-) -> None:
-    """
-    Test that the endpoint returns a 422 status code for various
-    invalid request payloads.
-    """
-    response = client.post("/api/v1/generate_prd", json=payload)
     assert response.status_code == 422
-    data = response.json()
-    assert "detail" in data
-    assert expected_msg in str(data["detail"])
+    assert "vanilla_openai" in str(response.json()["detail"])
+    assert "vanilla_google" in str(response.json()["detail"])

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -4,20 +4,26 @@ from fastapi.testclient import TestClient
 
 
 def test_health_check(client: TestClient) -> None:
-    """Test the health check endpoint."""
+    """`/health` reports liveness."""
     response = client.get("/health")
     assert response.status_code == 200
-    data = response.json()
-    assert data["status"] == "healthy"
-    assert data["service"] == "agentic-prd-generation"
+    assert response.json()["status"] == "healthy"
+    assert response.json()["service"] == "agentic-prd-generation"
+
+
+def test_readiness_check(client: TestClient) -> None:
+    """`/ready` reports the selected state backend."""
+    response = client.get("/ready")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready", "state_backend": "memory"}
 
 
 def test_root_endpoint(client: TestClient) -> None:
-    """Test the root endpoint."""
+    """The root endpoint exposes basic API metadata."""
     response = client.get("/")
     assert response.status_code == 200
     data = response.json()
-    assert "message" in data
-    assert "version" in data
-    assert "docs" in data
+    assert data["message"] == "Agentic PRD Generation API"
     assert data["version"] == "0.1.0"
+    assert data["docs"] == "/docs"
+    assert data["ready"] == "/ready"

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,0 +1,130 @@
+"""Unit tests for the PRD generation pipeline."""
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from backend.agents.base_adapter import AdapterError, BaseAdapter
+from backend.models import PRDState
+from backend.pipelines.pipeline_runner import create_diff, run_pipeline
+from backend.services.streamer import StreamerService
+from backend.state.base import StateStore
+
+
+@dataclass
+class RecordingStore(StateStore):
+    """Minimal in-memory store that records every saved state."""
+
+    history: list[PRDState] = field(default_factory=list)
+    backend_name: str = "memory"
+
+    async def save(self, state: PRDState) -> None:
+        self.history.append(state)
+
+    async def get(self, run_id: str) -> PRDState | None:
+        for state in reversed(self.history):
+            if state.run_id == run_id:
+                return state
+        return None
+
+    async def ping(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        return None
+
+
+class SequenceAdapter(BaseAdapter):
+    """Adapter test double that returns a predefined response sequence."""
+
+    def __init__(self, responses: list[str]):
+        self.adapter_type = "test"
+        self._responses = responses
+        self._index = 0
+
+    async def call_llm(self, prompt: str) -> str:
+        del prompt
+        response = self._responses[self._index]
+        self._index += 1
+        return response
+
+
+class FailingAdapter(BaseAdapter):
+    """Adapter test double that raises a typed provider error."""
+
+    adapter_type = "test"
+
+    async def call_llm(self, prompt: str) -> str:
+        del prompt
+        raise AdapterError("test", "provider blew up")
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_records_truthful_steps() -> None:
+    """A successful run records the expected ordered steps."""
+    store = RecordingStore()
+    streamer = StreamerService()
+    adapter = SequenceAdapter(
+        [
+            "# Outline\n\n- Goals",
+            "# Draft\n\nDetailed PRD",
+            "No issues found.",
+        ]
+    )
+    initial_state = PRDState(
+        run_id="run-1",
+        idea="An AI PM assistant",
+        step="Outline",
+        content="# PRD for An AI PM assistant\n\n_Starting outline generation..._",
+        revision=0,
+        diff=None,
+        error=None,
+    )
+
+    await run_pipeline(
+        initial_state=initial_state,
+        state_store=store,
+        adapter=adapter,
+        streamer=streamer,
+    )
+
+    assert [state.step for state in store.history] == [
+        "Outline",
+        "Draft",
+        "Critique",
+        "Complete",
+    ]
+    assert store.history[-1].step == "Complete"
+    assert store.history[-1].error is None
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_records_terminal_error_state() -> None:
+    """Provider failures end the run in an error state instead of completing."""
+    store = RecordingStore()
+    initial_state = PRDState(
+        run_id="run-2",
+        idea="A flaky provider",
+        step="Outline",
+        content="# PRD for A flaky provider\n\n_Starting outline generation..._",
+        revision=0,
+        diff=None,
+        error=None,
+    )
+
+    await run_pipeline(
+        initial_state=initial_state,
+        state_store=store,
+        adapter=FailingAdapter(),
+        streamer=None,
+    )
+
+    assert store.history[-1].step == "Error"
+    assert store.history[-1].error == "provider blew up"
+    assert all(state.step != "Complete" for state in store.history)
+
+
+def test_create_diff_returns_patch_text() -> None:
+    """Diff generation returns a patch when text changes."""
+    diff = create_diff("before", "after")
+    assert "@@" in diff

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -128,3 +128,46 @@ def test_create_diff_returns_patch_text() -> None:
     """Diff generation returns a patch when text changes."""
     diff = create_diff("before", "after")
     assert "@@" in diff
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_terminal_states_preserve_none_diff() -> None:
+    """Terminal states that explicitly disable diffs should keep `diff=None`."""
+    success_store = RecordingStore()
+    success_adapter = SequenceAdapter(
+        [
+            "# Outline\n\n- Goals",
+            "# Draft\n\nDetailed PRD",
+            "No issues found.",
+        ]
+    )
+    initial_state = PRDState(
+        run_id="run-3",
+        idea="Diff sentinel test",
+        step="Outline",
+        content="# PRD for Diff sentinel test\n\n_Starting outline generation..._",
+        revision=0,
+        diff=None,
+        error=None,
+    )
+
+    await run_pipeline(
+        initial_state=initial_state,
+        state_store=success_store,
+        adapter=success_adapter,
+        streamer=None,
+    )
+
+    assert success_store.history[-1].step == "Complete"
+    assert success_store.history[-1].diff is None
+
+    error_store = RecordingStore()
+    await run_pipeline(
+        initial_state=initial_state.model_copy(update={"run_id": "run-4"}),
+        state_store=error_store,
+        adapter=FailingAdapter(),
+        streamer=None,
+    )
+
+    assert error_store.history[-1].step == "Error"
+    assert error_store.history[-1].diff is None

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -59,6 +59,16 @@ class FailingAdapter(BaseAdapter):
         raise AdapterError("test", "provider blew up")
 
 
+class UnexpectedFailingAdapter(BaseAdapter):
+    """Adapter test double that raises an unexpected runtime error."""
+
+    adapter_type = "test"
+
+    async def call_llm(self, prompt: str) -> str:
+        del prompt
+        raise RuntimeError("unexpected boom")
+
+
 @pytest.mark.asyncio
 async def test_run_pipeline_records_truthful_steps() -> None:
     """A successful run records the expected ordered steps."""
@@ -122,6 +132,33 @@ async def test_run_pipeline_records_terminal_error_state() -> None:
     assert store.history[-1].step == "Error"
     assert store.history[-1].error == "provider blew up"
     assert all(state.step != "Complete" for state in store.history)
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_records_terminal_error_state_for_unexpected_failures() -> (
+    None
+):
+    """Unexpected exceptions should still end the run with an error state."""
+    store = RecordingStore()
+    initial_state = PRDState(
+        run_id="run-unexpected",
+        idea="Unexpected failure",
+        step="Outline",
+        content="# PRD for Unexpected failure\n\n_Starting outline generation..._",
+        revision=0,
+        diff=None,
+        error=None,
+    )
+
+    await run_pipeline(
+        initial_state=initial_state,
+        state_store=store,
+        adapter=UnexpectedFailingAdapter(),
+        streamer=None,
+    )
+
+    assert store.history[-1].step == "Error"
+    assert store.history[-1].error == "Unexpected pipeline error: unexpected boom"
 
 
 def test_create_diff_returns_patch_text() -> None:

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -1,0 +1,56 @@
+"""Unit tests for settings and runtime selection."""
+
+import pytest
+
+from backend.runtime import _build_state_store
+from backend.settings import AppSettings
+from backend.state.in_memory_store import InMemoryStore
+from backend.state.redis_store import RedisStore
+
+
+def test_settings_parse_env_lists_and_state_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Settings should parse env-backed JSON and literals correctly."""
+    monkeypatch.setenv("STATE_BACKEND", "memory")
+    monkeypatch.setenv("CORS_ORIGINS", '["http://localhost:3000"]')
+
+    settings = AppSettings()
+
+    assert settings.state_backend == "memory"
+    assert settings.cors_origins == ["http://localhost:3000"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_falls_back_to_memory_when_redis_is_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto mode falls back cleanly when Redis is unavailable."""
+    settings = AppSettings(state_backend="auto")
+
+    async def ping(self: RedisStore) -> bool:
+        del self
+        return False
+
+    monkeypatch.setattr(RedisStore, "ping", ping)
+
+    store = await _build_state_store(settings)
+
+    assert isinstance(store, InMemoryStore)
+
+
+@pytest.mark.asyncio
+async def test_runtime_raises_when_redis_is_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit Redis mode should fail fast when Redis is unavailable."""
+    settings = AppSettings(state_backend="redis")
+
+    async def ping(self: RedisStore) -> bool:
+        del self
+        return False
+
+    monkeypatch.setattr(RedisStore, "ping", ping)
+
+    with pytest.raises(RuntimeError, match="Redis was selected explicitly"):
+        await _build_state_store(settings)

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -45,12 +45,20 @@ async def test_runtime_raises_when_redis_is_required(
 ) -> None:
     """Explicit Redis mode should fail fast when Redis is unavailable."""
     settings = AppSettings(state_backend="redis")
+    closed = False
 
     async def ping(self: RedisStore) -> bool:
         del self
         return False
 
+    async def close(self: RedisStore) -> None:
+        del self
+        nonlocal closed
+        closed = True
+
     monkeypatch.setattr(RedisStore, "ping", ping)
+    monkeypatch.setattr(RedisStore, "close", close)
 
     with pytest.raises(RuntimeError, match="Redis was selected explicitly"):
         await _build_state_store(settings)
+    assert closed is True

--- a/tests/unit/test_streamer.py
+++ b/tests/unit/test_streamer.py
@@ -1,0 +1,37 @@
+"""Unit tests for the shared streamer service."""
+
+import asyncio
+
+import pytest
+
+from backend.services.streamer import StreamerService
+
+
+@pytest.mark.asyncio
+async def test_streamer_broadcasts_to_multiple_subscribers() -> None:
+    """All subscribers for a run should receive the same payload."""
+    streamer = StreamerService()
+    queue_one = await streamer.add_subscriber("run-1")
+    queue_two = await streamer.add_subscriber("run-1")
+
+    await streamer.publish("run-1", {"revision": 1, "step": "Outline"})
+
+    assert await asyncio.wait_for(queue_one.get(), timeout=1) == {
+        "revision": 1,
+        "step": "Outline",
+    }
+    assert await asyncio.wait_for(queue_two.get(), timeout=1) == {
+        "revision": 1,
+        "step": "Outline",
+    }
+
+
+@pytest.mark.asyncio
+async def test_streamer_cleans_up_subscribers() -> None:
+    """Removing the last subscriber clears the internal run registry."""
+    streamer = StreamerService()
+    queue = await streamer.add_subscriber("run-2")
+
+    await streamer.remove_subscriber("run-2", queue)
+
+    assert "run-2" not in streamer._queues


### PR DESCRIPTION
## Summary
- add lifespan-managed app settings/runtime resources, explicit store selection, and honest health/readiness semantics
- harden adapters, pipeline state transitions, and SSE replay/error handling for a reliable PRD-only MVP
- narrow the frontend/docs/package surface to implemented behavior and add regression coverage for runtime, streaming, pipeline, frontend helpers, and CLI wiring

## Verification
- ruff check .
- ruff format --check .
- mypy backend frontend tests
- pytest -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core request/streaming flow, runtime lifecycle, and LLM adapter error handling; regressions could break PRD runs or SSE replay despite added test coverage.
> 
> **Overview**
> Refactors the backend into a lifespan-managed runtime with centralized `AppSettings`, structured logging, and explicit state-backend selection (`redis`/`memory`/`auto` fallback) plus a new `/ready` endpoint that reflects store health.
> 
> Hardens generation/streaming by persisting richer `PRDState` (adds `idea` + terminal `error`), broadcasting via a shared fan-out `StreamerService`, and making `/api/v1/stream/{run_id}` replay the latest persisted state before streaming subsequent revisions (including terminal completion/error states).
> 
> Updates vanilla LLM adapters to use typed `AdapterError`, configurable models/timeouts, the `google-genai` SDK, and structured success/failure logging; pipeline execution now records truthful step transitions and persists terminal errors without faking successful content. Frontend/docs/env/Docker packaging are narrowed to shipped PRD-only behavior, and extensive unit/integration tests are added for runtime selection, SSE replay, pipeline transitions, CLI wiring, and frontend helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb46c14767be71e60777f470c45372e81d85601f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->